### PR TITLE
Feature/27 total board read

### DIFF
--- a/src/main/java/com/estsoft/guesshangeul/board/controller/BoardController.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/controller/BoardController.java
@@ -1,0 +1,52 @@
+package com.estsoft.guesshangeul.board.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.estsoft.guesshangeul.board.dto.BoardResponse;
+import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
+import com.estsoft.guesshangeul.board.dto.QuizBoardDto;
+import com.estsoft.guesshangeul.board.service.GeneralBoardService;
+import com.estsoft.guesshangeul.board.service.QuizBoardService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/board")
+public class BoardController {
+	private final GeneralBoardService generalBoardService;
+	private final QuizBoardService quizBoardService;
+
+	@GetMapping
+	public ResponseEntity<List<BoardResponse>> readAllExistingGeneralBoard(
+		@PageableDefault(size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+		// 삭제되지 않은 게시판 리스트를 반환
+
+		// 일반 게시판 요청
+		List<GeneralBoardDto> generalBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(false, pageable);
+		List<BoardResponse> generalBoardResponse = generalBoardList.stream().map(BoardResponse::new).toList();
+		List<BoardResponse> response = new ArrayList<>(generalBoardResponse);
+
+		// 나온 게시판 목록 개수 제외하여 나머지 개수만큼 요청
+		int offset = generalBoardList.size();
+		Pageable nextPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort())
+			.withPage(pageable.getPageNumber() + (offset / pageable.getPageSize()));
+
+		// 퀴즈 게시판 요청
+		List<QuizBoardDto> quizBoardList = quizBoardService.findAllQuizBoardByIsDeleted(false, nextPageable);
+		List<BoardResponse> quizBoardResponse = quizBoardList.stream().map(BoardResponse::new).toList();
+		response.addAll(quizBoardResponse);
+
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/board/controller/GeneralBoardController.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/controller/GeneralBoardController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
 import com.estsoft.guesshangeul.board.dto.GeneralBoardResponse;
 import com.estsoft.guesshangeul.board.service.GeneralBoardService;
 
@@ -21,7 +22,8 @@ public class GeneralBoardController {
 	@GetMapping
 	public ResponseEntity<List<GeneralBoardResponse>> readAllExistingGeneralBoard() {
 		// 삭제되지 않은 일반 게시판 리스트를 반환
-		List<GeneralBoardResponse> response = generalBoardService.findAllGeneralBoardByIsDeleted(false);
+		List<GeneralBoardDto> result = generalBoardService.findAllGeneralBoardByIsDeleted(false);
+		List<GeneralBoardResponse> response = result.stream().map(GeneralBoardResponse::new).toList();
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/controller/GeneralBoardController.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/controller/GeneralBoardController.java
@@ -2,6 +2,9 @@ package com.estsoft.guesshangeul.board.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,9 +23,10 @@ public class GeneralBoardController {
 	private final GeneralBoardService generalBoardService;
 
 	@GetMapping
-	public ResponseEntity<List<GeneralBoardResponse>> readAllExistingGeneralBoard() {
+	public ResponseEntity<List<GeneralBoardResponse>> readAllExistingGeneralBoard(
+		@PageableDefault(size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 		// 삭제되지 않은 일반 게시판 리스트를 반환
-		List<GeneralBoardDto> result = generalBoardService.findAllGeneralBoardByIsDeleted(false);
+		List<GeneralBoardDto> result = generalBoardService.findAllGeneralBoardByIsDeleted(false, pageable);
 		List<GeneralBoardResponse> response = result.stream().map(GeneralBoardResponse::new).toList();
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/estsoft/guesshangeul/board/controller/QuizBoardController.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/controller/QuizBoardController.java
@@ -2,6 +2,9 @@ package com.estsoft.guesshangeul.board.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,9 +39,10 @@ public class QuizBoardController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<QuizBoardResponse>> readAllExistingQuizBoard() {
+	public ResponseEntity<List<QuizBoardResponse>> readAllExistingQuizBoard(
+		@PageableDefault(size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 		// 삭제되지 않은 퀴즈 게시판 리스트를 반환
-		List<QuizBoardDto> result = quizBoardService.findAllQuizBoardByIsDeleted(false);
+		List<QuizBoardDto> result = quizBoardService.findAllQuizBoardByIsDeleted(false, pageable);
 		List<QuizBoardResponse> response = result.stream().map(QuizBoardResponse::new).toList();
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/estsoft/guesshangeul/board/dto/BoardResponse.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/dto/BoardResponse.java
@@ -1,0 +1,32 @@
+package com.estsoft.guesshangeul.board.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class BoardResponse {
+	private Long id;
+	private String title;
+	private LocalDateTime createdAt;
+	private Boolean isDeleted;
+	private Integer boardType;  // 문제 게시판 or 일반 게시판
+
+	public BoardResponse(GeneralBoardDto generalBoardDto) {
+		this.id = generalBoardDto.getId();
+		this.title = generalBoardDto.getTitle();
+		this.createdAt = generalBoardDto.getCreatedAt();
+		this.isDeleted = generalBoardDto.getIsDeleted();
+		this.boardType = BoardType.GENERAL_BOARD;
+	}
+
+	public BoardResponse(QuizBoardDto quizBoardDto) {
+		this.id = quizBoardDto.getId();
+		this.title = quizBoardDto.getTitle();
+		this.createdAt = quizBoardDto.getCreatedAt();
+		this.isDeleted = quizBoardDto.getIsDeleted();
+		this.boardType = BoardType.QUIZ_BOARD;
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/board/dto/BoardType.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/dto/BoardType.java
@@ -1,0 +1,6 @@
+package com.estsoft.guesshangeul.board.dto;
+
+public class BoardType {
+	public static final int GENERAL_BOARD = 1;
+	public static final int QUIZ_BOARD = 2;
+}

--- a/src/main/java/com/estsoft/guesshangeul/board/dto/GeneralBoardDto.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/dto/GeneralBoardDto.java
@@ -2,19 +2,20 @@ package com.estsoft.guesshangeul.board.dto;
 
 import java.time.LocalDateTime;
 
+import com.estsoft.guesshangeul.board.entity.GeneralBoard;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class GeneralBoardResponse {
+public class GeneralBoardDto {
 	private Long id;
 	private String title;
-	private Long userId;
 	private LocalDateTime createdAt;
 	private Boolean isDeleted;
 
-	public GeneralBoardResponse(GeneralBoardDto generalBoard) {
+	public GeneralBoardDto(GeneralBoard generalBoard) {
 		this.id = generalBoard.getId();
 		this.title = generalBoard.getTitle();
 		this.createdAt = generalBoard.getCreatedAt();

--- a/src/main/java/com/estsoft/guesshangeul/board/dto/QuizBoardDto.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/dto/QuizBoardDto.java
@@ -19,7 +19,7 @@ public class QuizBoardDto {
 	public QuizBoardDto(QuizBoard quizBoard) {
 		this.id = quizBoard.getId();
 		this.title = quizBoard.getTitle();
-		this.userId = quizBoard.getUserId();
+		this.userId = quizBoard.getUsers().getId();
 		this.createdAt = quizBoard.getCreatedAt();
 		this.isDeleted = quizBoard.getIsDeleted();
 	}

--- a/src/main/java/com/estsoft/guesshangeul/board/entity/QuizBoard.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/entity/QuizBoard.java
@@ -6,12 +6,16 @@ import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.estsoft.guesshangeul.user.entity.Users;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,8 +36,9 @@ public class QuizBoard {
 	@Column(nullable = false)
 	private String title;
 
-	@Column(nullable = false)
-	private Long userId;
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private Users users;
 
 	@CreatedDate
 	@Column(name = "created_at")
@@ -43,9 +48,9 @@ public class QuizBoard {
 	@ColumnDefault("false")
 	private Boolean isDeleted;
 
-	public QuizBoard(String title, Long userId, Boolean isDeleted) {
+	public QuizBoard(String title, Users users, Boolean isDeleted) {
 		this.title = title;
-		this.userId = userId;
+		this.users = users;
 		this.isDeleted = isDeleted;
 	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/repository/GeneralBoardRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/repository/GeneralBoardRepository.java
@@ -2,6 +2,7 @@ package com.estsoft.guesshangeul.board.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,5 @@ import com.estsoft.guesshangeul.board.entity.GeneralBoard;
 
 @Repository
 public interface GeneralBoardRepository extends JpaRepository<GeneralBoard, Long> {
-	List<GeneralBoard> findAllByIsDeleted(boolean isDeleted);
+	List<GeneralBoard> findAllByIsDeleted(boolean isDeleted, Pageable pageable);
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/repository/QuizBoardRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/repository/QuizBoardRepository.java
@@ -3,6 +3,7 @@ package com.estsoft.guesshangeul.board.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +11,7 @@ import com.estsoft.guesshangeul.board.entity.QuizBoard;
 
 @Repository
 public interface QuizBoardRepository extends JpaRepository<QuizBoard, Long> {
-	List<QuizBoard> findAllByIsDeleted(boolean isDeleted);
+	List<QuizBoard> findAllByIsDeleted(boolean isDeleted, Pageable pageable);
 
 	Optional<QuizBoard> findByTitle(String title);
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/service/GeneralBoardService.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/service/GeneralBoardService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.estsoft.guesshangeul.board.dto.GeneralBoardResponse;
+import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
 import com.estsoft.guesshangeul.board.entity.GeneralBoard;
 import com.estsoft.guesshangeul.board.repository.GeneralBoardRepository;
 
@@ -15,8 +15,8 @@ import lombok.RequiredArgsConstructor;
 public class GeneralBoardService {
 	private final GeneralBoardRepository generalBoardRepository;
 
-	public List<GeneralBoardResponse> findAllGeneralBoardByIsDeleted(Boolean isDeleted) {
+	public List<GeneralBoardDto> findAllGeneralBoardByIsDeleted(Boolean isDeleted) {
 		List<GeneralBoard> generalBoardList = generalBoardRepository.findAllByIsDeleted(isDeleted);
-		return generalBoardList.stream().map(GeneralBoardResponse::new).toList();
+		return generalBoardList.stream().map(GeneralBoardDto::new).toList();
 	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/service/GeneralBoardService.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/service/GeneralBoardService.java
@@ -2,6 +2,7 @@ package com.estsoft.guesshangeul.board.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
@@ -15,8 +16,8 @@ import lombok.RequiredArgsConstructor;
 public class GeneralBoardService {
 	private final GeneralBoardRepository generalBoardRepository;
 
-	public List<GeneralBoardDto> findAllGeneralBoardByIsDeleted(Boolean isDeleted) {
-		List<GeneralBoard> generalBoardList = generalBoardRepository.findAllByIsDeleted(isDeleted);
+	public List<GeneralBoardDto> findAllGeneralBoardByIsDeleted(Boolean isDeleted, Pageable pageable) {
+		List<GeneralBoard> generalBoardList = generalBoardRepository.findAllByIsDeleted(isDeleted, pageable);
 		return generalBoardList.stream().map(GeneralBoardDto::new).toList();
 	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/service/QuizBoardService.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/service/QuizBoardService.java
@@ -14,7 +14,6 @@ import com.estsoft.guesshangeul.board.entity.QuizBoard;
 import com.estsoft.guesshangeul.board.repository.QuizBoardRepository;
 import com.estsoft.guesshangeul.user.entity.Users;
 import com.estsoft.guesshangeul.user.service.UsersDetailsService;
-import com.estsoft.guesshangeul.user.service.UsersService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 public class QuizBoardService {
 	private final QuizBoardRepository quizBoardRepository;
 	private final UsersDetailsService usersDetailsService;
-	private final UsersService usersService;
 
 	public List<QuizBoardDto> findAllQuizBoardByIsDeleted(Boolean isDeleted) {
 		List<QuizBoard> quizBoardList = quizBoardRepository.findAllByIsDeleted(isDeleted);
@@ -37,14 +35,11 @@ public class QuizBoardService {
 
 	public QuizBoardDto addNewQuizBoard(QuizBoardCreateRequest request) {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		String username = ((Users)authentication.getPrincipal()).getUsername();
+		String username = ((UserDetails)authentication.getPrincipal()).getUsername();
 
-		UserDetails userDetails = usersDetailsService.loadUserByUsername(username);
-		String email = userDetails.getUsername();
-		Users users = usersService.findUserByEmail(email);
-		Long userId = users.getId();
+		Users users = (Users)usersDetailsService.loadUserByUsername(username);
 		String title = request.getTitle();
-		QuizBoard quizBoard = quizBoardRepository.save(new QuizBoard(title, userId, false));
+		QuizBoard quizBoard = quizBoardRepository.save(new QuizBoard(title, users, false));
 
 		return new QuizBoardDto(quizBoard);
 	}

--- a/src/main/java/com/estsoft/guesshangeul/board/service/QuizBoardService.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/service/QuizBoardService.java
@@ -3,6 +3,7 @@ package com.estsoft.guesshangeul.board.service;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -23,8 +24,8 @@ public class QuizBoardService {
 	private final QuizBoardRepository quizBoardRepository;
 	private final UsersDetailsService usersDetailsService;
 
-	public List<QuizBoardDto> findAllQuizBoardByIsDeleted(Boolean isDeleted) {
-		List<QuizBoard> quizBoardList = quizBoardRepository.findAllByIsDeleted(isDeleted);
+	public List<QuizBoardDto> findAllQuizBoardByIsDeleted(Boolean isDeleted, Pageable pageable) {
+		List<QuizBoard> quizBoardList = quizBoardRepository.findAllByIsDeleted(isDeleted, pageable);
 		return quizBoardList.stream().map(QuizBoardDto::new).toList();
 	}
 

--- a/src/test/java/com/estsoft/guesshangeul/controller/board/BoardControllerTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/controller/board/BoardControllerTest.java
@@ -1,0 +1,67 @@
+package com.estsoft.guesshangeul.controller.board;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.estsoft.guesshangeul.board.controller.BoardController;
+import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
+import com.estsoft.guesshangeul.board.dto.QuizBoardDto;
+import com.estsoft.guesshangeul.board.entity.GeneralBoard;
+import com.estsoft.guesshangeul.board.entity.QuizBoard;
+import com.estsoft.guesshangeul.board.service.GeneralBoardService;
+import com.estsoft.guesshangeul.board.service.QuizBoardService;
+import com.estsoft.guesshangeul.user.entity.Users;
+
+@WebMvcTest(controllers = BoardController.class)
+@WithMockUser
+public class BoardControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private GeneralBoardService generalBoardService;
+
+	@MockBean
+	private QuizBoardService quizBoardService;
+
+	@Test
+	void testReadAllExistingGeneralBoardSuccess() throws Exception {
+		// given
+		Users users = new Users(1L, "example@email.com");
+		GeneralBoard generalBoard = new GeneralBoard("title1", false);
+		QuizBoard quizBoard = new QuizBoard("title2", users, false);
+		List<GeneralBoardDto> generalBoardDtos = List.of(new GeneralBoardDto(generalBoard));
+		List<QuizBoardDto> quizBoardDtos = List.of(new QuizBoardDto(quizBoard));
+
+		when(generalBoardService.findAllGeneralBoardByIsDeleted(eq(false), any(Pageable.class)))
+			.thenReturn(generalBoardDtos);
+		when(quizBoardService.findAllQuizBoardByIsDeleted(eq(false), any(Pageable.class)))
+			.thenReturn(quizBoardDtos);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/board")
+			.accept(MediaType.APPLICATION_JSON)).andDo(print());
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].title").value("title1"))
+			.andExpect(jsonPath("$[0].isDeleted").value(false))
+			.andExpect(jsonPath("$[1].title").value("title2"))
+			.andExpect(jsonPath("$[1].isDeleted").value(false));
+	}
+}

--- a/src/test/java/com/estsoft/guesshangeul/controller/board/GeneralBoardControllerTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/controller/board/GeneralBoardControllerTest.java
@@ -2,6 +2,7 @@ package com.estsoft.guesshangeul.controller.board;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,11 +36,12 @@ public class GeneralBoardControllerTest {
 		// given
 		GeneralBoard generalBoard = new GeneralBoard("title1", false);
 		List<GeneralBoardDto> result = List.of(new GeneralBoardDto(generalBoard));
-		when(generalBoardService.findAllGeneralBoardByIsDeleted(false)).thenReturn(result);
+		when(generalBoardService.findAllGeneralBoardByIsDeleted(eq(false), any(Pageable.class)))
+			.thenReturn(result);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(get("/api/generalBoard")
-			.accept(MediaType.APPLICATION_JSON));
+			.accept(MediaType.APPLICATION_JSON)).andDo(print());
 
 		// then
 		resultActions.andExpect(status().isOk())

--- a/src/test/java/com/estsoft/guesshangeul/controller/board/GeneralBoardControllerTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/controller/board/GeneralBoardControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.estsoft.guesshangeul.board.controller.GeneralBoardController;
-import com.estsoft.guesshangeul.board.dto.GeneralBoardResponse;
+import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
 import com.estsoft.guesshangeul.board.entity.GeneralBoard;
 import com.estsoft.guesshangeul.board.service.GeneralBoardService;
 
@@ -32,8 +32,8 @@ public class GeneralBoardControllerTest {
 	@Test
 	void testReadAllExistingGeneralBoardSuccess() throws Exception {
 		// given
-		GeneralBoard quizBoard = new GeneralBoard("title1", false);
-		List<GeneralBoardResponse> result = List.of(new GeneralBoardResponse(quizBoard));
+		GeneralBoard generalBoard = new GeneralBoard("title1", false);
+		List<GeneralBoardDto> result = List.of(new GeneralBoardDto(generalBoard));
 		when(generalBoardService.findAllGeneralBoardByIsDeleted(false)).thenReturn(result);
 
 		// when

--- a/src/test/java/com/estsoft/guesshangeul/controller/board/QuizBoardControllerTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/controller/board/QuizBoardControllerTest.java
@@ -21,6 +21,7 @@ import com.estsoft.guesshangeul.board.dto.QuizBoardCreateRequest;
 import com.estsoft.guesshangeul.board.dto.QuizBoardDto;
 import com.estsoft.guesshangeul.board.entity.QuizBoard;
 import com.estsoft.guesshangeul.board.service.QuizBoardService;
+import com.estsoft.guesshangeul.user.entity.Users;
 import com.estsoft.guesshangeul.user.service.UsersService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -42,7 +43,8 @@ public class QuizBoardControllerTest {
 	@Test
 	void testReadAllExistingQuizBoardSuccess() throws Exception {
 		// given
-		QuizBoard quizBoard = new QuizBoard("title1", 1L, false);
+		Users users = new Users(1L, "example@email.com");
+		QuizBoard quizBoard = new QuizBoard("title1", users, false);
 		List<QuizBoardDto> result = List.of(new QuizBoardDto(quizBoard));
 		when(quizBoardService.findAllQuizBoardByIsDeleted(false)).thenReturn(result);
 
@@ -58,7 +60,8 @@ public class QuizBoardControllerTest {
 	@Test
 	void testCreateQuizBoardSuccess() throws Exception {
 		// given
-		QuizBoard quizBoard = new QuizBoard("title", 1L, false);
+		Users users = new Users(1L, "example@email.com");
+		QuizBoard quizBoard = new QuizBoard("title", users, false);
 		QuizBoardDto result = new QuizBoardDto(quizBoard);
 		QuizBoardCreateRequest request = new QuizBoardCreateRequest(quizBoard.getTitle());
 		String json = objectMapper.writeValueAsString(request);

--- a/src/test/java/com/estsoft/guesshangeul/controller/board/QuizBoardControllerTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/controller/board/QuizBoardControllerTest.java
@@ -3,6 +3,7 @@ package com.estsoft.guesshangeul.controller.board;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -46,11 +48,12 @@ public class QuizBoardControllerTest {
 		Users users = new Users(1L, "example@email.com");
 		QuizBoard quizBoard = new QuizBoard("title1", users, false);
 		List<QuizBoardDto> result = List.of(new QuizBoardDto(quizBoard));
-		when(quizBoardService.findAllQuizBoardByIsDeleted(false)).thenReturn(result);
+		when(quizBoardService.findAllQuizBoardByIsDeleted(eq(false), any(Pageable.class)))
+			.thenReturn(result);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(get("/api/quizBoard")
-			.accept(MediaType.APPLICATION_JSON));
+			.accept(MediaType.APPLICATION_JSON)).andDo(print());
 
 		// then
 		resultActions.andExpect(status().isOk())

--- a/src/test/java/com/estsoft/guesshangeul/repository/board/GeneralBoardRepositoryTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/repository/board/GeneralBoardRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Pageable;
 
 import com.estsoft.guesshangeul.board.entity.GeneralBoard;
 import com.estsoft.guesshangeul.board.repository.GeneralBoardRepository;
@@ -28,8 +29,10 @@ public class GeneralBoardRepositoryTest {
 		generalBoardRepository.saveAll(List.of(generalBoard1, generalBoard2, generalBoard3));
 
 		// when
-		List<GeneralBoard> existingGeneralBoardList = generalBoardRepository.findAllByIsDeleted(false);
-		List<GeneralBoard> deletedGeneralBoardList = generalBoardRepository.findAllByIsDeleted(true);
+		List<GeneralBoard> existingGeneralBoardList = generalBoardRepository.findAllByIsDeleted(false,
+			Pageable.unpaged());
+		List<GeneralBoard> deletedGeneralBoardList = generalBoardRepository.findAllByIsDeleted(true,
+			Pageable.unpaged());
 
 		// then
 		assertThat(existingGeneralBoardList).hasSize(2);

--- a/src/test/java/com/estsoft/guesshangeul/repository/board/QuizBoardRepositoryTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/repository/board/QuizBoardRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -13,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import com.estsoft.guesshangeul.board.entity.QuizBoard;
 import com.estsoft.guesshangeul.board.repository.QuizBoardRepository;
+import com.estsoft.guesshangeul.user.entity.Users;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -20,12 +22,18 @@ public class QuizBoardRepositoryTest {
 	@Autowired
 	private QuizBoardRepository quizBoardRepository;
 
+	@BeforeEach
+	void setup() {
+		quizBoardRepository.deleteAll();
+	}
+
 	@Test
 	void testFindAllByIsDeletedSuccess() {
 		// given
-		QuizBoard quizBoard1 = new QuizBoard("title1", 1L, false);
-		QuizBoard quizBoard2 = new QuizBoard("title2", 2L, false);
-		QuizBoard quizBoard3 = new QuizBoard("title3", 3L, true);
+		Users users = new Users(1L, "example@email.com");
+		QuizBoard quizBoard1 = new QuizBoard("title1", users, false);
+		QuizBoard quizBoard2 = new QuizBoard("title2", users, false);
+		QuizBoard quizBoard3 = new QuizBoard("title3", users, true);
 
 		quizBoardRepository.saveAll(List.of(quizBoard1, quizBoard2, quizBoard3));
 
@@ -36,25 +44,26 @@ public class QuizBoardRepositoryTest {
 		// then
 		assertThat(existingQuizBoardList).hasSize(2);
 		assertThat(existingQuizBoardList.get(0).getTitle()).isEqualTo("title1");
-		assertThat(existingQuizBoardList.get(0).getUserId()).isEqualTo(1L);
+		assertThat(existingQuizBoardList.get(0).getUsers()).isEqualTo(users);
 		assertThat(existingQuizBoardList.get(0).getIsDeleted()).isFalse();
 
 		assertThat(existingQuizBoardList.get(1).getTitle()).isEqualTo("title2");
-		assertThat(existingQuizBoardList.get(1).getUserId()).isEqualTo(2L);
+		assertThat(existingQuizBoardList.get(0).getUsers()).isEqualTo(users);
 		assertThat(existingQuizBoardList.get(1).getIsDeleted()).isFalse();
 
 		assertThat(deletedQuizBoardList).hasSize(1);
 		assertThat(deletedQuizBoardList.get(0).getTitle()).isEqualTo("title3");
-		assertThat(deletedQuizBoardList.get(0).getUserId()).isEqualTo(3L);
+		assertThat(existingQuizBoardList.get(0).getUsers()).isEqualTo(users);
 		assertThat(deletedQuizBoardList.get(0).getIsDeleted()).isTrue();
 	}
 
 	@Test
 	void testFindByTitleSuccess() {
 		// given
-		QuizBoard quizBoard1 = new QuizBoard("title1", 1L, false);
-		QuizBoard quizBoard2 = new QuizBoard("title2", 2L, false);
-		QuizBoard quizBoard3 = new QuizBoard("title3", 3L, true);
+		Users users = new Users(1L, "example@email.com");
+		QuizBoard quizBoard1 = new QuizBoard("title1", users, false);
+		QuizBoard quizBoard2 = new QuizBoard("title2", users, false);
+		QuizBoard quizBoard3 = new QuizBoard("title3", users, true);
 
 		quizBoardRepository.saveAll(List.of(quizBoard1, quizBoard2, quizBoard3));
 
@@ -65,7 +74,7 @@ public class QuizBoardRepositoryTest {
 		// then
 		assertTrue(result1.isPresent());
 		assertThat(result1.get().getTitle()).isEqualTo("title1");
-		assertThat(result1.get().getUserId()).isEqualTo(1L);
+		assertThat(result1.get().getUsers()).isEqualTo(users);
 		assertFalse(result1.get().getIsDeleted());
 
 		assertTrue(result2.isEmpty());

--- a/src/test/java/com/estsoft/guesshangeul/repository/board/QuizBoardRepositoryTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/repository/board/QuizBoardRepositoryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Pageable;
 
 import com.estsoft.guesshangeul.board.entity.QuizBoard;
 import com.estsoft.guesshangeul.board.repository.QuizBoardRepository;
@@ -38,8 +39,8 @@ public class QuizBoardRepositoryTest {
 		quizBoardRepository.saveAll(List.of(quizBoard1, quizBoard2, quizBoard3));
 
 		// when
-		List<QuizBoard> existingQuizBoardList = quizBoardRepository.findAllByIsDeleted(false);
-		List<QuizBoard> deletedQuizBoardList = quizBoardRepository.findAllByIsDeleted(true);
+		List<QuizBoard> existingQuizBoardList = quizBoardRepository.findAllByIsDeleted(false, Pageable.unpaged());
+		List<QuizBoard> deletedQuizBoardList = quizBoardRepository.findAllByIsDeleted(true, Pageable.unpaged());
 
 		// then
 		assertThat(existingQuizBoardList).hasSize(2);

--- a/src/test/java/com/estsoft/guesshangeul/service/board/GeneralBoardServiceTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/service/board/GeneralBoardServiceTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
@@ -33,8 +34,10 @@ public class GeneralBoardServiceTest {
 		generalBoardRepository.saveAll(List.of(generalBoard1, generalBoard2, generalBoard3));
 
 		// when
-		List<GeneralBoardDto> existingGeneralBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(false);
-		List<GeneralBoardDto> deletedGeneralBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(true);
+		List<GeneralBoardDto> existingGeneralBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(false,
+			Pageable.unpaged());
+		List<GeneralBoardDto> deletedGeneralBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(true,
+			Pageable.unpaged());
 
 		// then
 		assertThat(existingGeneralBoardList).hasSize(2);

--- a/src/test/java/com/estsoft/guesshangeul/service/board/GeneralBoardServiceTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/service/board/GeneralBoardServiceTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.estsoft.guesshangeul.board.dto.GeneralBoardResponse;
+import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
 import com.estsoft.guesshangeul.board.entity.GeneralBoard;
 import com.estsoft.guesshangeul.board.repository.GeneralBoardRepository;
 import com.estsoft.guesshangeul.board.service.GeneralBoardService;
@@ -33,8 +33,8 @@ public class GeneralBoardServiceTest {
 		generalBoardRepository.saveAll(List.of(generalBoard1, generalBoard2, generalBoard3));
 
 		// when
-		List<GeneralBoardResponse> existingGeneralBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(false);
-		List<GeneralBoardResponse> deletedGeneralBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(true);
+		List<GeneralBoardDto> existingGeneralBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(false);
+		List<GeneralBoardDto> deletedGeneralBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(true);
 
 		// then
 		assertThat(existingGeneralBoardList).hasSize(2);

--- a/src/test/java/com/estsoft/guesshangeul/service/board/QuizBoardServiceTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/service/board/QuizBoardServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,8 +54,10 @@ public class QuizBoardServiceTest {
 		quizBoardRepository.saveAll(List.of(quizBoard1, quizBoard2, quizBoard3));
 
 		// when
-		List<QuizBoardDto> existingQuizBoardList = quizBoardService.findAllQuizBoardByIsDeleted(false);
-		List<QuizBoardDto> deletedQuizBoardList = quizBoardService.findAllQuizBoardByIsDeleted(true);
+		List<QuizBoardDto> existingQuizBoardList = quizBoardService.findAllQuizBoardByIsDeleted(false,
+			Pageable.unpaged());
+		List<QuizBoardDto> deletedQuizBoardList = quizBoardService.findAllQuizBoardByIsDeleted(true,
+			Pageable.unpaged());
 
 		// then
 		assertThat(existingQuizBoardList).hasSize(2);

--- a/src/test/java/com/estsoft/guesshangeul/service/board/QuizBoardServiceTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/service/board/QuizBoardServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,12 +37,18 @@ public class QuizBoardServiceTest {
 	@MockBean
 	private UsersService usersService;
 
+	@BeforeEach
+	void setup() {
+		quizBoardRepository.deleteAll();
+	}
+
 	@Test
 	void testFindAllQuizBoardByIsDeletedSuccess() {
 		// given
-		QuizBoard quizBoard1 = new QuizBoard("title1", 1L, false);
-		QuizBoard quizBoard2 = new QuizBoard("title2", 2L, false);
-		QuizBoard quizBoard3 = new QuizBoard("title3", 3L, true);
+		Users users = new Users(1L, "example@email.com");
+		QuizBoard quizBoard1 = new QuizBoard("title1", users, false);
+		QuizBoard quizBoard2 = new QuizBoard("title2", users, false);
+		QuizBoard quizBoard3 = new QuizBoard("title3", users, true);
 
 		quizBoardRepository.saveAll(List.of(quizBoard1, quizBoard2, quizBoard3));
 
@@ -56,12 +63,12 @@ public class QuizBoardServiceTest {
 		assertThat(existingQuizBoardList.get(0).getIsDeleted()).isFalse();
 
 		assertThat(existingQuizBoardList.get(1).getTitle()).isEqualTo("title2");
-		assertThat(existingQuizBoardList.get(1).getUserId()).isEqualTo(2L);
+		assertThat(existingQuizBoardList.get(1).getUserId()).isEqualTo(1L);
 		assertThat(existingQuizBoardList.get(1).getIsDeleted()).isFalse();
 
 		assertThat(deletedQuizBoardList).hasSize(1);
 		assertThat(deletedQuizBoardList.get(0).getTitle()).isEqualTo("title3");
-		assertThat(deletedQuizBoardList.get(0).getUserId()).isEqualTo(3L);
+		assertThat(deletedQuizBoardList.get(0).getUserId()).isEqualTo(1L);
 		assertThat(deletedQuizBoardList.get(0).getIsDeleted()).isTrue();
 	}
 
@@ -73,7 +80,7 @@ public class QuizBoardServiceTest {
 		Users users = new Users(1L, "example@email.com");
 		String username = anyString();
 		when(usersDetailsService.loadUserByUsername(username)).thenReturn(users);
-		when(usersService.findUserByEmail(users.getEmail())).thenReturn(users);
+		// when(usersService.findUserByEmail(users.getEmail())).thenReturn(users);
 
 		// when
 		QuizBoardDto quizBoard = quizBoardService.addNewQuizBoard(request);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

### DB 구조 변경
**QuizBoard의 Long userId -> Users users 로 변경**
- 프로젝트의 entity들이 매핑된 형태이므로 스타일 통일
- 추후 관계 매핑 활용 가능성
### 페이지네이션 적용
GeneralBoard, QuizBoard 조회 기능 페이지네이션 설정
- 전체 게시판 조회에 필요
- 게시판 조회에 개수 제한 적용
### 전체 게시판 조회 기능 추가
- 일반 게시판 -> 문제 게시판 우선순위
- 기본값 총 6개 게시판 조회
- 추후 post를 함께 출력하는 것 고려
- BoardType 값으로 문제, 일반 게시판 구분

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

Entity 수정에 따라 다른 로직에 영향을 줄 가능성이 있을지 검토 부탁드려요~