### PR TITLE
Feature/41 check user duplication

### DIFF
--- a/src/main/java/com/estsoft/guesshangeul/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/estsoft/guesshangeul/exception/GlobalExceptionHandler.java
@@ -16,4 +16,9 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<String> handleEntityDuplicateException(EntityAttributeDuplicateException exception) {
 		return ResponseEntity.status(HttpStatus.CONFLICT).body(exception.getMessage());
 	}
+
+	@ExceptionHandler(InvalidInputException.class)
+	public ResponseEntity<String> handleEntityDuplicateException(InvalidInputException exception) {
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/exception/InvalidEmailFormatException.java
+++ b/src/main/java/com/estsoft/guesshangeul/exception/InvalidEmailFormatException.java
@@ -1,0 +1,7 @@
+package com.estsoft.guesshangeul.exception;
+
+public class InvalidEmailFormatException extends InvalidInputException {
+	public InvalidEmailFormatException(String email) {
+		super("email", email);
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/exception/InvalidInputException.java
+++ b/src/main/java/com/estsoft/guesshangeul/exception/InvalidInputException.java
@@ -1,0 +1,7 @@
+package com.estsoft.guesshangeul.exception;
+
+public class InvalidInputException extends RuntimeException {
+	public <T> InvalidInputException(String inputName, T inputValue) {
+		super("Wrong " + inputName + ": " + inputValue);
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/exception/InvalidNicknameFormatException.java
+++ b/src/main/java/com/estsoft/guesshangeul/exception/InvalidNicknameFormatException.java
@@ -1,0 +1,7 @@
+package com.estsoft.guesshangeul.exception;
+
+public class InvalidNicknameFormatException extends InvalidInputException {
+	public InvalidNicknameFormatException(String nickname) {
+		super("nickname", nickname);
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/exception/UsersEmailDuplicateException.java
+++ b/src/main/java/com/estsoft/guesshangeul/exception/UsersEmailDuplicateException.java
@@ -1,0 +1,7 @@
+package com.estsoft.guesshangeul.exception;
+
+public class UsersEmailDuplicateException extends EntityAttributeDuplicateException {
+	public UsersEmailDuplicateException(String value) {
+		super("Users", "email", value);
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/exception/UsersNicknameDuplicateException.java
+++ b/src/main/java/com/estsoft/guesshangeul/exception/UsersNicknameDuplicateException.java
@@ -1,0 +1,7 @@
+package com.estsoft.guesshangeul.exception;
+
+public class UsersNicknameDuplicateException extends EntityAttributeDuplicateException {
+	public UsersNicknameDuplicateException(String value) {
+		super("Users", "nickname", value);
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/user/controller/UsersController.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/controller/UsersController.java
@@ -59,7 +59,7 @@ public class UsersController {
 				.toList());
 	}
 
-	@PostMapping("/emailExists")
+	@PostMapping("/checkEmailDuplicate")
 	public ResponseEntity<CheckEmailExistsResponse> checkEmailExists(@RequestBody CheckEmailExistsRequest request) {
 		String email = request.getEmail();
 		Boolean result = usersService.checkEmailExists(email);
@@ -68,7 +68,7 @@ public class UsersController {
 		return ResponseEntity.ok(response);
 	}
 
-	@PostMapping("/nicknameExists")
+	@PostMapping("/checkNicknameDuplicate")
 	public ResponseEntity<CheckNicknameExistsResponse> checkNicknameExists(
 		@RequestBody CheckNicknameExistsRequest request) {
 		String nickname = request.getNickname();

--- a/src/main/java/com/estsoft/guesshangeul/user/controller/UsersController.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/controller/UsersController.java
@@ -15,6 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.estsoft.guesshangeul.user.dto.AddAuthorityRequest;
 import com.estsoft.guesshangeul.user.dto.AddAuthorityResponse;
 import com.estsoft.guesshangeul.user.dto.AddUserRequest;
+import com.estsoft.guesshangeul.user.dto.CheckEmailExistsRequest;
+import com.estsoft.guesshangeul.user.dto.CheckEmailExistsResponse;
+import com.estsoft.guesshangeul.user.dto.CheckNicknameExistsRequest;
+import com.estsoft.guesshangeul.user.dto.CheckNicknameExistsResponse;
 import com.estsoft.guesshangeul.user.entity.Authorities;
 import com.estsoft.guesshangeul.user.entity.Users;
 import com.estsoft.guesshangeul.user.service.UsersService;
@@ -53,5 +57,24 @@ public class UsersController {
 					Authority.getId(), Authority.getUserId(), Authority.getAuthority()
 				))
 				.toList());
+	}
+
+	@PostMapping("/emailExists")
+	public ResponseEntity<CheckEmailExistsResponse> checkEmailExists(@RequestBody CheckEmailExistsRequest request) {
+		String email = request.getEmail();
+		Boolean result = usersService.checkEmailExists(email);
+		String message = result ? "이메일이 존재합니다." : "존재하지 않는 이메일입니다.";
+		CheckEmailExistsResponse response = new CheckEmailExistsResponse(email, result, message);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/nicknameExists")
+	public ResponseEntity<CheckNicknameExistsResponse> checkNicknameExists(
+		@RequestBody CheckNicknameExistsRequest request) {
+		String nickname = request.getNickname();
+		Boolean result = usersService.checkNicknameExists(nickname);
+		String message = result ? "닉네임이 존재합니다." : "존재하지 않는 닉네임입니다.";
+		CheckNicknameExistsResponse response = new CheckNicknameExistsResponse(nickname, result, message);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/user/dto/AddUserRequest.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/dto/AddUserRequest.java
@@ -2,9 +2,11 @@ package com.estsoft.guesshangeul.user.dto;
 
 import com.estsoft.guesshangeul.user.entity.Users;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+@AllArgsConstructor
 @Getter
 @Setter
 public class AddUserRequest {

--- a/src/main/java/com/estsoft/guesshangeul/user/dto/CheckEmailExistsRequest.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/dto/CheckEmailExistsRequest.java
@@ -1,0 +1,12 @@
+package com.estsoft.guesshangeul.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CheckEmailExistsRequest {
+	private String email;
+}

--- a/src/main/java/com/estsoft/guesshangeul/user/dto/CheckEmailExistsResponse.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/dto/CheckEmailExistsResponse.java
@@ -1,0 +1,12 @@
+package com.estsoft.guesshangeul.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckEmailExistsResponse {
+	private String email;
+	private Boolean isExists;
+	private String message;
+}

--- a/src/main/java/com/estsoft/guesshangeul/user/dto/CheckNicknameExistsRequest.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/dto/CheckNicknameExistsRequest.java
@@ -1,0 +1,12 @@
+package com.estsoft.guesshangeul.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CheckNicknameExistsRequest {
+	private String nickname;
+}

--- a/src/main/java/com/estsoft/guesshangeul/user/dto/CheckNicknameExistsResponse.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/dto/CheckNicknameExistsResponse.java
@@ -1,0 +1,12 @@
+package com.estsoft.guesshangeul.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckNicknameExistsResponse {
+	private String nickname;
+	private Boolean isExists;
+	private String message;
+}

--- a/src/main/java/com/estsoft/guesshangeul/user/repository/UsersRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/repository/UsersRepository.java
@@ -8,4 +8,6 @@ import com.estsoft.guesshangeul.user.entity.Users;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
 	Optional<Users> findByEmail(String email);
+
+	Optional<Users> findByNickname(String nickname);
 }

--- a/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
@@ -26,7 +26,7 @@ public class UsersService {
 	private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
 	private static final Pattern EMAIL_PATTERN = Pattern.compile(
-		"^(?=.{1,64}@)[A-Za-z0-9_-]+(\\\\.[A-Za-z0-9_-]+)*@[^-][A-Za-z0-9-]+(\\\\.[A-Za-z0-9-]+)*(\\\\.[A-Za-z]{2,})$"
+		"^(?=.{1,64}@)[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)*@[^-][A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z]{2,})$"
 	);
 
 	public void checkEmailPattern(String email) {

--- a/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
@@ -8,6 +8,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.estsoft.guesshangeul.exception.InvalidEmailFormatException;
+import com.estsoft.guesshangeul.exception.UsersEmailDuplicateException;
+import com.estsoft.guesshangeul.exception.UsersNicknameDuplicateException;
 import com.estsoft.guesshangeul.exception.UsersNotFoundException;
 import com.estsoft.guesshangeul.user.dto.AddAuthorityRequest;
 import com.estsoft.guesshangeul.user.dto.AddUserRequest;
@@ -40,6 +42,14 @@ public class UsersService {
 	}
 
 	public Users save(AddUserRequest request) {
+		String email = request.getEmail();
+		if (checkEmailExists(email)) {
+			throw new UsersEmailDuplicateException(email);
+		}
+		String nickname = request.getNickname();
+		if (checkNicknameExists(request.getNickname())) {
+			throw new UsersNicknameDuplicateException(nickname);
+		}
 		request.setPassword(bCryptPasswordEncoder.encode(request.getPassword()));
 		return usersRepository.save(request.toEntity());
 	}

--- a/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
@@ -1,10 +1,13 @@
 package com.estsoft.guesshangeul.user.service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.estsoft.guesshangeul.exception.InvalidEmailFormatException;
 import com.estsoft.guesshangeul.exception.UsersNotFoundException;
 import com.estsoft.guesshangeul.user.dto.AddAuthorityRequest;
 import com.estsoft.guesshangeul.user.dto.AddUserRequest;
@@ -22,6 +25,16 @@ public class UsersService {
 	private final AuthoritiesRepository authoritiesRepository;
 	private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
+	private static final Pattern EMAIL_PATTERN = Pattern.compile(
+		"^(?=.{1,64}@)[A-Za-z0-9_-]+(\\\\.[A-Za-z0-9_-]+)*@[^-][A-Za-z0-9-]+(\\\\.[A-Za-z0-9-]+)*(\\\\.[A-Za-z]{2,})$"
+	);
+
+	public void checkEmailPattern(String email) {
+		if (!EMAIL_PATTERN.matcher(email).matches()) {
+			throw new InvalidEmailFormatException(email);
+		}
+	}
+
 	public Users findUserByEmail(String email) {
 		return usersRepository.findByEmail(email).orElseThrow(() -> new UsersNotFoundException("email", email));
 	}
@@ -29,6 +42,12 @@ public class UsersService {
 	public Users save(AddUserRequest request) {
 		request.setPassword(bCryptPasswordEncoder.encode(request.getPassword()));
 		return usersRepository.save(request.toEntity());
+	}
+
+	public Boolean checkEmailExists(String email) {
+		checkEmailPattern(email);
+		Optional<Users> result = usersRepository.findByEmail(email);
+		return result.isPresent();
 	}
 
 	public List<Authorities> saveAuthorities(List<AddAuthorityRequest> addAuthorityRequestList) {

--- a/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
@@ -8,6 +8,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.estsoft.guesshangeul.exception.InvalidEmailFormatException;
+import com.estsoft.guesshangeul.exception.InvalidNicknameFormatException;
 import com.estsoft.guesshangeul.exception.UsersEmailDuplicateException;
 import com.estsoft.guesshangeul.exception.UsersNicknameDuplicateException;
 import com.estsoft.guesshangeul.exception.UsersNotFoundException;
@@ -31,9 +32,19 @@ public class UsersService {
 		"^(?=.{1,64}@)[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)*@[^-][A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z]{2,})$"
 	);
 
+	private static final Pattern NICKNAME_PATTERN = Pattern.compile(
+		"^[가-힣a-zA-Z0-9._-]{2,20}$"
+	);
+
 	public void checkEmailPattern(String email) {
 		if (!EMAIL_PATTERN.matcher(email).matches()) {
 			throw new InvalidEmailFormatException(email);
+		}
+	}
+
+	public void checkNicknamePattern(String nickname) {
+		if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
+			throw new InvalidNicknameFormatException(nickname);
 		}
 	}
 
@@ -61,6 +72,7 @@ public class UsersService {
 	}
 
 	public Boolean checkNicknameExists(String nickname) {
+		checkNicknamePattern(nickname);
 		Optional<Users> result = usersRepository.findByNickname(nickname);
 		return result.isPresent();
 	}

--- a/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
+++ b/src/main/java/com/estsoft/guesshangeul/user/service/UsersService.java
@@ -50,6 +50,11 @@ public class UsersService {
 		return result.isPresent();
 	}
 
+	public Boolean checkNicknameExists(String nickname) {
+		Optional<Users> result = usersRepository.findByNickname(nickname);
+		return result.isPresent();
+	}
+
 	public List<Authorities> saveAuthorities(List<AddAuthorityRequest> addAuthorityRequestList) {
 		List<Authorities> authorities = addAuthorityRequestList.stream()
 			.map(AddAuthorityRequest::toEntity)

--- a/src/test/java/com/estsoft/guesshangeul/controller/user/UsersControllerTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/controller/user/UsersControllerTest.java
@@ -47,13 +47,13 @@ public class UsersControllerTest {
 		doReturn(false).when(usersService).checkEmailExists(email2);
 
 		// when
-		ResultActions resultActions1 = mockMvc.perform(post("/api/emailExists")
+		ResultActions resultActions1 = mockMvc.perform(post("/api/checkEmailDuplicate")
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON)
 			.content(json1)
 			.with(csrf()));
 
-		ResultActions resultActions2 = mockMvc.perform(post("/api/emailExists")
+		ResultActions resultActions2 = mockMvc.perform(post("/api/checkEmailDuplicate")
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON)
 			.content(json2)
@@ -84,13 +84,13 @@ public class UsersControllerTest {
 		doReturn(false).when(usersService).checkNicknameExists(nickname2);
 
 		// when
-		ResultActions resultActions1 = mockMvc.perform(post("/api/nicknameExists")
+		ResultActions resultActions1 = mockMvc.perform(post("/api/checkNicknameDuplicate")
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON)
 			.content(json1)
 			.with(csrf()));
 
-		ResultActions resultActions2 = mockMvc.perform(post("/api/nicknameExists")
+		ResultActions resultActions2 = mockMvc.perform(post("/api/checkNicknameDuplicate")
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON)
 			.content(json2)

--- a/src/test/java/com/estsoft/guesshangeul/controller/user/UsersControllerTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/controller/user/UsersControllerTest.java
@@ -1,0 +1,108 @@
+package com.estsoft.guesshangeul.controller.user;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.estsoft.guesshangeul.user.controller.UsersController;
+import com.estsoft.guesshangeul.user.dto.CheckEmailExistsRequest;
+import com.estsoft.guesshangeul.user.dto.CheckNicknameExistsRequest;
+import com.estsoft.guesshangeul.user.service.UsersService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = UsersController.class)
+@WithMockUser
+public class UsersControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private UsersService usersService;
+
+	@Test
+	void testCheckEmailExistsSuccess() throws Exception {
+		// given
+		String email1 = "exists@email.com";
+		CheckEmailExistsRequest request1 = new CheckEmailExistsRequest(email1);
+		String json1 = objectMapper.writeValueAsString(request1);
+
+		String email2 = "not-exists@email.com";
+		CheckEmailExistsRequest request2 = new CheckEmailExistsRequest(email2);
+		String json2 = objectMapper.writeValueAsString(request2);
+
+		doReturn(true).when(usersService).checkEmailExists(email1);
+		doReturn(false).when(usersService).checkEmailExists(email2);
+
+		// when
+		ResultActions resultActions1 = mockMvc.perform(post("/api/emailExists")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(json1)
+			.with(csrf()));
+
+		ResultActions resultActions2 = mockMvc.perform(post("/api/emailExists")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(json2)
+			.with(csrf()));
+
+		// then
+		resultActions1.andExpect(status().isOk())
+			.andExpect(jsonPath("$.email").value(email1))
+			.andExpect(jsonPath("$.isExists").value(true));
+
+		resultActions2.andExpect(status().isOk())
+			.andExpect(jsonPath("$.email").value(email2))
+			.andExpect(jsonPath("$.isExists").value(false));
+	}
+
+	@Test
+	void testCheckNicknameExistsSuccess() throws Exception {
+		// given
+		String nickname1 = "exists123";
+		CheckNicknameExistsRequest request1 = new CheckNicknameExistsRequest(nickname1);
+		String json1 = objectMapper.writeValueAsString(request1);
+
+		String nickname2 = "not-exists-123";
+		CheckNicknameExistsRequest request2 = new CheckNicknameExistsRequest(nickname2);
+		String json2 = objectMapper.writeValueAsString(request2);
+
+		doReturn(true).when(usersService).checkNicknameExists(nickname1);
+		doReturn(false).when(usersService).checkNicknameExists(nickname2);
+
+		// when
+		ResultActions resultActions1 = mockMvc.perform(post("/api/nicknameExists")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(json1)
+			.with(csrf()));
+
+		ResultActions resultActions2 = mockMvc.perform(post("/api/nicknameExists")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(json2)
+			.with(csrf()));
+
+		// then
+		resultActions1.andExpect(status().isOk())
+			.andExpect(jsonPath("$.nickname").value(nickname1))
+			.andExpect(jsonPath("$.isExists").value(true));
+
+		resultActions2.andExpect(status().isOk())
+			.andExpect(jsonPath("$.nickname").value(nickname2))
+			.andExpect(jsonPath("$.isExists").value(false));
+	}
+}

--- a/src/test/java/com/estsoft/guesshangeul/service/user/UsersServiceTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/service/user/UsersServiceTest.java
@@ -66,4 +66,22 @@ public class UsersServiceTest {
 				"Wrong on email: " + email);
 		}
 	}
+
+	@Test
+	void testCheckNicknameExistsSuccess() {
+		// given
+		String exists = "exist-user";
+		String notExists = "not-exists";
+
+		Users users = new Users("user@example.com", "", exists);
+		usersRepository.save(users);
+
+		// when
+		Boolean nicknameExists = usersService.checkNicknameExists(exists);
+		Boolean nicknameNotExists = usersService.checkNicknameExists(notExists);
+
+		// then
+		assertTrue(nicknameExists);
+		assertFalse(nicknameNotExists);
+	}
 }

--- a/src/test/java/com/estsoft/guesshangeul/service/user/UsersServiceTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/service/user/UsersServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.estsoft.guesshangeul.exception.InvalidEmailFormatException;
+import com.estsoft.guesshangeul.exception.InvalidNicknameFormatException;
 import com.estsoft.guesshangeul.exception.UsersEmailDuplicateException;
 import com.estsoft.guesshangeul.exception.UsersNicknameDuplicateException;
 import com.estsoft.guesshangeul.user.dto.AddUserRequest;
@@ -66,6 +67,39 @@ public class UsersServiceTest {
 		for (String email : invalidEmails) {
 			assertThrows(InvalidEmailFormatException.class, () -> usersService.checkEmailExists(email),
 				"Wrong on email: " + email);
+		}
+	}
+
+	@Test
+	void testCheckNicknamePatternSuccess() {
+		// given
+		List<String> validNickname = List.of(
+			"한글닉네임123",
+			"english123",
+			"20nickname1234567890", // 20 characters
+			"한글20글자닉네임_1234567890"
+		);
+
+		// when & then
+		for (String nickname : validNickname) {
+			assertDoesNotThrow(() -> usersService.checkNicknamePattern(nickname));
+		}
+	}
+
+	@Test
+	void testCheckNicknameExistsThrowsInvalidNicknameFormatException() {
+		// given
+		List<String> invalidNickname = List.of(
+			"",
+			"ㄱㄴ",
+			"123456789012345678901", // over 20 characters
+			"공 백"
+		);
+
+		// when & then
+		for (String nickname : invalidNickname) {
+			assertThrows(InvalidNicknameFormatException.class, () -> usersService.checkNicknameExists(nickname),
+				"Wrong on nickname: " + nickname);
 		}
 	}
 

--- a/src/test/java/com/estsoft/guesshangeul/service/user/UsersServiceTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/service/user/UsersServiceTest.java
@@ -1,0 +1,69 @@
+package com.estsoft.guesshangeul.service.user;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.estsoft.guesshangeul.exception.InvalidEmailFormatException;
+import com.estsoft.guesshangeul.user.entity.Users;
+import com.estsoft.guesshangeul.user.repository.UsersRepository;
+import com.estsoft.guesshangeul.user.service.UsersService;
+
+@SpringBootTest
+@Transactional
+public class UsersServiceTest {
+	@Autowired
+	private UsersService usersService;
+	@Autowired
+	private UsersRepository usersRepository;
+
+	@BeforeEach
+	void setup() {
+		usersRepository.deleteAll();
+	}
+
+	@Test
+	void testCheckEmailExistsSuccess() {
+		// given
+		String exists = "exists@email.com";
+		String notExists = "not-exists@email.com";
+
+		Users users = new Users(exists, "", "test");
+		usersRepository.save(users);
+
+		// when
+		Boolean emailExists = usersService.checkEmailExists(exists);
+		Boolean emailNotExists = usersService.checkEmailExists(notExists);
+
+		// then
+		assertTrue(emailExists);
+		assertFalse(emailNotExists);
+	}
+
+	@Test
+	void testCheckEmailExistsThrowsInvalidEmailFormatException() {
+		// given
+		List<String> invalidEmails = List.of(
+			"", // empty
+			"plainaddress", // missing @
+			"@missingusername.com", // missing username
+			"username@.com", // missing domain name
+			"username@com", // missing dot in domain
+			"username@domain..com", // double dot in domain
+			"username@domain.c", // single character domain
+			"username@domain.corporate" // too long TLD
+		);
+
+		// when & then
+		for (String email : invalidEmails) {
+			assertThrows(InvalidEmailFormatException.class, () -> usersService.checkEmailExists(email),
+				"Wrong on email: " + email);
+		}
+	}
+}

--- a/src/test/java/com/estsoft/guesshangeul/service/user/UsersServiceTest.java
+++ b/src/test/java/com/estsoft/guesshangeul/service/user/UsersServiceTest.java
@@ -56,8 +56,7 @@ public class UsersServiceTest {
 			"username@.com", // missing domain name
 			"username@com", // missing dot in domain
 			"username@domain..com", // double dot in domain
-			"username@domain.c", // single character domain
-			"username@domain.corporate" // too long TLD
+			"username@domain.c" // single character domain
 		);
 
 		// when & then


### PR DESCRIPTION
## #️⃣연관된 이슈

> #41 

## 📝작업 내용

### 이메일 중복 검사 로직 구현
- 이메일 유효성 검사
- 이메일 중복 검사
- POST /api/emailExists

### 닉네임 중복 검사 로직 구현
- 닉네임 유효성 검사
  - 기준: 한/영/숫자 2~20글자
- 닉네임 중복 검사
- POST /api/nicknameExists

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
