### PR TITLE
fix: GeneralBoardResponse 생성자 누락

### DIFF
--- a/src/main/java/com/estsoft/guesshangeul/board/dto/GeneralBoardResponse.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/dto/GeneralBoardResponse.java
@@ -2,6 +2,8 @@ package com.estsoft.guesshangeul.board.dto;
 
 import java.time.LocalDateTime;
 
+import com.estsoft.guesshangeul.board.entity.GeneralBoard;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,6 +15,13 @@ public class GeneralBoardResponse {
 	private Long userId;
 	private LocalDateTime createdAt;
 	private Boolean isDeleted;
+
+	public GeneralBoardResponse(GeneralBoard generalBoard) {
+		this.id = generalBoard.getId();
+		this.title = generalBoard.getTitle();
+		this.createdAt = generalBoard.getCreatedAt();
+		this.isDeleted = generalBoard.getIsDeleted();
+	}
 
 	public GeneralBoardResponse(GeneralBoardDto generalBoard) {
 		this.id = generalBoard.getId();


### PR DESCRIPTION
GeneralBoardResponse에 GeneralBoard 파라미터를 갖는 생성자 추가

## #️⃣연관된 이슈

> #27, #45

## 📝작업 내용

GeneralBoardResponse에 GeneralBoard 파라미터를 갖는 생성자 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요