### PR TITLE
Feature/48 퀴즈 게시판 생성 페이지

### DIFF
--- a/src/main/java/com/estsoft/guesshangeul/board/controller/BoardViewController.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/controller/BoardViewController.java
@@ -1,0 +1,15 @@
+package com.estsoft.guesshangeul.board.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class BoardViewController {
+	@GetMapping("/createBoard")
+	public String createBoard() {
+		return "createBoard";
+	}
+}

--- a/src/main/resources/static/js/createBoard.js
+++ b/src/main/resources/static/js/createBoard.js
@@ -1,0 +1,30 @@
+function createBoard() {
+    const boardTitle = document.getElementById("board-title").value;
+    const data = {
+        title: boardTitle
+    };
+
+    fetch('/api/quizBoard', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+    })
+        .then(response => {
+            if (response.ok) {
+                alert("게시판을 생성했습니다.");
+                window.location.replace("/quizBoard");
+                return response.json();
+            } else if (response.status === 409) {
+                throw new Error("이미 존재하는 게시판 제목입니다.");
+            } else if (response.status === 403) {
+                throw new Error("권한이 없습니다.");
+            } else {
+                throw new Error('게시판 생성 실패');
+            }
+        })
+        .catch(error => {
+            alert(error);
+        });
+}

--- a/src/main/resources/templates/common/withdrawalModal.html
+++ b/src/main/resources/templates/common/withdrawalModal.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<th:block th:fragment="withdrawalModal">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<th:block th:fragment="withdrawalModal" sec:authorize="isAuthenticated()">
     <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">

--- a/src/main/resources/templates/createBoard.html
+++ b/src/main/resources/templates/createBoard.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{/common/defaultLayout}">
+<head>
+    <title>게시판 생성</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+
+<body>
+<th:block layout:fragment="content">
+    <div class="container d-flex align-items-center justify-content-center flex-grow-1">
+        <div class="col-6 mb-5">
+            <h3 class="text-center mb-5">게시판 생성</h3>
+            <div class="col-12 mb-5">
+                <label for="board-title" class="form-label">게시판 제목</label>
+                <input type="text" class="form-control" id="board-title" placeholder="게시글 제목" required="">
+            </div>
+
+            <button class="w-100 btn btn-primary btn-lg" onclick="createBoard()">생성</button>
+
+        </div>
+    </div>
+    <script th:src="@{/js/createBoard.js}"></script>
+</th:block>
+
+</body>
+</html>


### PR DESCRIPTION
## #️⃣연관된 이슈

#48 

## 📝작업 내용

게시판 생성 페이지 추가
- 게시판 제목으로 POST /api/quizBoard
- 추후 /quizBoard 이동할 URL 변경 가능성 존재

### 스크린샷
![image](https://github.com/user-attachments/assets/1828697f-1695-4c55-8034-a9ccbe1d703f)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요