### PR TITLE
홈페이지 구현

### DIFF
--- a/src/main/java/com/estsoft/guesshangeul/admin/service/AdminService.java
+++ b/src/main/java/com/estsoft/guesshangeul/admin/service/AdminService.java
@@ -85,7 +85,7 @@ public class AdminService {
 		List<QuizPost> quizPosts = quizPostRepository.findByQuizBoardIdAndIdIn(quizBoardId,
 			quizPostId);
 		for (QuizPost quizPost : quizPosts) {
-			quizPost.setIsHidden(true);
+			quizPost.setHidden(true);
 			quizPostRepository.save(quizPost);
 		}
 		return quizPosts;
@@ -96,7 +96,7 @@ public class AdminService {
 		List<QuizPost> quizPosts = quizPostRepository.findByQuizBoardIdAndIdIn(quizBoardId,
 			quizPostId);
 		for (QuizPost quizPost : quizPosts) {
-			quizPost.setIsHidden(false);
+			quizPost.setHidden(false);
 			quizPostRepository.save(quizPost);
 		}
 		return quizPosts;

--- a/src/main/java/com/estsoft/guesshangeul/board/controller/BoardController.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/controller/BoardController.java
@@ -1,9 +1,7 @@
 package com.estsoft.guesshangeul.board.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -13,10 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.estsoft.guesshangeul.board.dto.BoardResponse;
-import com.estsoft.guesshangeul.board.dto.GeneralBoardDto;
-import com.estsoft.guesshangeul.board.dto.QuizBoardDto;
-import com.estsoft.guesshangeul.board.service.GeneralBoardService;
-import com.estsoft.guesshangeul.board.service.QuizBoardService;
+import com.estsoft.guesshangeul.board.service.BoardService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,28 +19,12 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/board")
 public class BoardController {
-	private final GeneralBoardService generalBoardService;
-	private final QuizBoardService quizBoardService;
+	private final BoardService boardService;
 
 	@GetMapping
-	public ResponseEntity<List<BoardResponse>> readAllExistingGeneralBoard(
+	public ResponseEntity<List<BoardResponse>> readTotalBoard(
 		@PageableDefault(size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-		// 삭제되지 않은 게시판 리스트를 반환
-
-		// 일반 게시판 요청
-		List<GeneralBoardDto> generalBoardList = generalBoardService.findAllGeneralBoardByIsDeleted(false, pageable);
-		List<BoardResponse> generalBoardResponse = generalBoardList.stream().map(BoardResponse::new).toList();
-		List<BoardResponse> response = new ArrayList<>(generalBoardResponse);
-
-		// 나온 게시판 목록 개수 제외하여 나머지 개수만큼 요청
-		int offset = generalBoardList.size();
-		Pageable nextPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort())
-			.withPage(pageable.getPageNumber() + (offset / pageable.getPageSize()));
-
-		// 퀴즈 게시판 요청
-		List<QuizBoardDto> quizBoardList = quizBoardService.findAllQuizBoardByIsDeleted(false, nextPageable);
-		List<BoardResponse> quizBoardResponse = quizBoardList.stream().map(BoardResponse::new).toList();
-		response.addAll(quizBoardResponse);
+		List<BoardResponse> response = boardService.readTotalBoard(pageable);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/estsoft/guesshangeul/board/controller/BoardViewController.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/controller/BoardViewController.java
@@ -1,15 +1,31 @@
 package com.estsoft.guesshangeul.board.controller;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+
+import com.estsoft.guesshangeul.board.dto.BoardResponse;
+import com.estsoft.guesshangeul.board.service.BoardService;
 
 import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequiredArgsConstructor
 public class BoardViewController {
+	private final BoardService boardService;
+
 	@GetMapping("/createBoard")
 	public String createBoard() {
 		return "createBoard";
+	}
+
+	@GetMapping("/")
+	public String home(Model model) {
+		List<BoardResponse> boardResponses = boardService.readTotalBoard(Pageable.ofSize(6));
+		model.addAttribute("boards", boardResponses);
+		return "index";
 	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/dto/BoardResponse.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/dto/BoardResponse.java
@@ -1,9 +1,15 @@
 package com.estsoft.guesshangeul.board.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
+
+import com.estsoft.guesshangeul.board.entity.GeneralBoard;
+import com.estsoft.guesshangeul.board.entity.QuizBoard;
+import com.estsoft.guesshangeul.post.dto.PostResponse;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @AllArgsConstructor
 @Getter
@@ -12,21 +18,23 @@ public class BoardResponse {
 	private String title;
 	private LocalDateTime createdAt;
 	private Boolean isDeleted;
-	private Integer boardType;  // 문제 게시판 or 일반 게시판
+	private Integer boardType;  // 일반 게시판(1) or 문제 게시판(2)
+	@Setter
+	private List<PostResponse> posts;
 
-	public BoardResponse(GeneralBoardDto generalBoardDto) {
-		this.id = generalBoardDto.getId();
-		this.title = generalBoardDto.getTitle();
-		this.createdAt = generalBoardDto.getCreatedAt();
-		this.isDeleted = generalBoardDto.getIsDeleted();
+	public BoardResponse(GeneralBoard generalBoard) {
+		this.id = generalBoard.getId();
+		this.title = generalBoard.getTitle();
+		this.createdAt = generalBoard.getCreatedAt();
+		this.isDeleted = generalBoard.getIsDeleted();
 		this.boardType = BoardType.GENERAL_BOARD;
 	}
 
-	public BoardResponse(QuizBoardDto quizBoardDto) {
-		this.id = quizBoardDto.getId();
-		this.title = quizBoardDto.getTitle();
-		this.createdAt = quizBoardDto.getCreatedAt();
-		this.isDeleted = quizBoardDto.getIsDeleted();
+	public BoardResponse(QuizBoard quizBoard) {
+		this.id = quizBoard.getId();
+		this.title = quizBoard.getTitle();
+		this.createdAt = quizBoard.getCreatedAt();
+		this.isDeleted = quizBoard.getIsDeleted();
 		this.boardType = BoardType.QUIZ_BOARD;
 	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/repository/GeneralBoardRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/repository/GeneralBoardRepository.java
@@ -11,4 +11,20 @@ import com.estsoft.guesshangeul.board.entity.GeneralBoard;
 @Repository
 public interface GeneralBoardRepository extends JpaRepository<GeneralBoard, Long> {
 	List<GeneralBoard> findAllByIsDeleted(boolean isDeleted, Pageable pageable);
+
+	// Fetch Join 활용
+	// @Query("""
+	// 	SELECT DISTINCT b FROM GeneralBoard b
+	// 	JOIN FETCH b.posts p
+	// 	JOIN FETCH p.user u
+	// 	WHERE p.isHidden = false
+	// 	  AND b.id IN (
+	// 	      SELECT subB.id FROM GeneralBoard subB
+	// 	      WHERE subB.isDeleted = false
+	// 	      ORDER BY subB.createdAt DESC
+	// 	      LIMIT 6
+	// 	  )
+	// 	ORDER BY b.createdAt DESC, p.createdAt DESC
+	// 	""")
+	// List<GeneralBoard> findAllTop6Boards();
 }

--- a/src/main/java/com/estsoft/guesshangeul/board/service/BoardService.java
+++ b/src/main/java/com/estsoft/guesshangeul/board/service/BoardService.java
@@ -1,0 +1,90 @@
+package com.estsoft.guesshangeul.board.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.estsoft.guesshangeul.board.dto.BoardResponse;
+import com.estsoft.guesshangeul.board.entity.GeneralBoard;
+import com.estsoft.guesshangeul.board.entity.QuizBoard;
+import com.estsoft.guesshangeul.board.repository.GeneralBoardRepository;
+import com.estsoft.guesshangeul.board.repository.QuizBoardRepository;
+import com.estsoft.guesshangeul.comment.repository.GeneralCommentRepository;
+import com.estsoft.guesshangeul.comment.repository.QuizCommentRepository;
+import com.estsoft.guesshangeul.post.dto.PostResponse;
+import com.estsoft.guesshangeul.post.entity.GeneralPost;
+import com.estsoft.guesshangeul.post.entity.QuizPost;
+import com.estsoft.guesshangeul.post.repository.GeneralPostRepository;
+import com.estsoft.guesshangeul.post.repository.QuizPostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class BoardService {
+	private final GeneralBoardRepository generalBoardRepository;
+	private final QuizBoardRepository quizBoardRepository;
+	private final GeneralPostRepository generalPostRepository;
+	private final QuizPostRepository quizPostRepository;
+	private final GeneralCommentRepository generalCommentRepository;
+	private final QuizCommentRepository quizCommentRepository;
+
+	@Transactional
+	public List<BoardResponse> readTotalBoard(
+		@PageableDefault(size = 6, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+		// 일반 게시판 요청
+		List<GeneralBoard> generalBoardList = generalBoardRepository.findAllByIsDeleted(false, Pageable.ofSize(6));
+		List<BoardResponse> generalBoardResponse = generalBoardList.stream().map(
+			board -> {
+				List<GeneralPost> generalPosts = generalPostRepository.findTop5ByGeneralBoardIdOrderByCreatedAtDesc(
+					board.getId());
+				BoardResponse response = new BoardResponse(board);
+
+				List<PostResponse> generalPostResponseList = generalPosts.stream().map(post -> {
+					PostResponse postResponse = new PostResponse(post);
+					Long commentCount = generalCommentRepository.countByPostId(post.getId());
+					postResponse.setCommentCount(commentCount);
+					return postResponse;
+				}).toList();
+				response.setPosts(generalPostResponseList);
+
+				return response;
+			}
+		).toList();
+		List<BoardResponse> result = new ArrayList<>(generalBoardResponse);
+
+		// 나온 게시판 목록 개수 제외하여 나머지 개수만큼 요청
+		int offset = generalBoardList.size();
+		Pageable nextPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort())
+			.withPage(pageable.getPageNumber() + (offset / pageable.getPageSize()));
+
+		// 퀴즈 게시판 요청
+		List<QuizBoard> quizBoardList = quizBoardRepository.findAllByIsDeleted(false, nextPageable);
+		List<BoardResponse> quizBoardResponse = quizBoardList.stream().map(
+			board -> {
+				List<QuizPost> quizPosts = quizPostRepository.findTop5ByQuizBoardIdOrderByCreatedAtDesc(
+					board.getId());
+				BoardResponse response = new BoardResponse(board);
+
+				List<PostResponse> quizPostResponseList = quizPosts.stream().map(post -> {
+					PostResponse postResponse = new PostResponse(post);
+					Long commentCount = quizCommentRepository.countByPostId(post.getId());
+					postResponse.setCommentCount(commentCount);
+					return postResponse;
+				}).toList();
+				response.setPosts(quizPostResponseList);
+
+				return response;
+			}
+		).toList();
+		result.addAll(quizBoardResponse);
+
+		return result;
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/comment/repository/GeneralCommentRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/comment/repository/GeneralCommentRepository.java
@@ -1,10 +1,13 @@
 package com.estsoft.guesshangeul.comment.repository;
 
-import com.estsoft.guesshangeul.comment.entity.GeneralComment;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import com.estsoft.guesshangeul.comment.entity.GeneralComment;
 
 public interface GeneralCommentRepository extends JpaRepository<GeneralComment, Long> {
 	List<GeneralComment> findByPostId(Long postId);
+
+	Long countByPostId(Long postId);
 }

--- a/src/main/java/com/estsoft/guesshangeul/comment/repository/QuizCommentRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/comment/repository/QuizCommentRepository.java
@@ -1,10 +1,13 @@
 package com.estsoft.guesshangeul.comment.repository;
 
-import com.estsoft.guesshangeul.comment.entity.QuizComment;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import com.estsoft.guesshangeul.comment.entity.QuizComment;
 
 public interface QuizCommentRepository extends JpaRepository<QuizComment, Long> {
 	List<QuizComment> findByPostId(Long postId);
+
+	Long countByPostId(Long postId);
 }

--- a/src/main/java/com/estsoft/guesshangeul/post/controller/GeneralPostController.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/controller/GeneralPostController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.estsoft.guesshangeul.post.dto.AddGeneralPostRequest;
 import com.estsoft.guesshangeul.post.dto.GeneralPostResponse;
-import com.estsoft.guesshangeul.post.dto.GetHiddenPostResponse;
 import com.estsoft.guesshangeul.post.dto.UpdateGeneralPostRequest;
 import com.estsoft.guesshangeul.post.service.GeneralPostService;
 
@@ -55,8 +54,8 @@ public class GeneralPostController {
 	public ResponseEntity<GeneralPostResponse> createGeneralPost(@RequestBody AddGeneralPostRequest request,
 		@PathVariable Long generalBoardId) {
 		GeneralPostResponse post = generalPostService.createGeneralPost(request, generalBoardId);
-		return ResponseEntity.status(HttpStatus.CREATED).body(post);}
-
+		return ResponseEntity.status(HttpStatus.CREATED).body(post);
+	}
 
 	// 게시글 수정
 	@PutMapping("/{general_post_id}")

--- a/src/main/java/com/estsoft/guesshangeul/post/controller/GeneralPostController.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/controller/GeneralPostController.java
@@ -1,57 +1,73 @@
 package com.estsoft.guesshangeul.post.controller;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.estsoft.guesshangeul.post.dto.AddGeneralPostRequest;
 import com.estsoft.guesshangeul.post.dto.GeneralPostResponse;
 import com.estsoft.guesshangeul.post.dto.UpdateGeneralPostRequest;
 import com.estsoft.guesshangeul.post.service.GeneralPostService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
-@RequestMapping("/api/generalBoard/{general_board_id}/generalPost")
+@RequestMapping("/api/generalBoard/{generalBoardId}/generalPost")
 public class GeneralPostController {
-    private final GeneralPostService generalPostService;
+	private final GeneralPostService generalPostService;
 
-    public GeneralPostController(GeneralPostService generalPostService) {
-        this.generalPostService = generalPostService;
-    }
-    // 전체 게시글 조회
-    @GetMapping
-    public ResponseEntity<List<GeneralPostResponse>> getAllGeneralPosts() {
-        List<GeneralPostResponse> posts = generalPostService.getAllGeneralPosts();
-        return ResponseEntity.status(HttpStatus.OK).body(posts);
-    }
-    // 게시글 id로 조회
-    @GetMapping("/{general_post_id}")
-    public ResponseEntity<GeneralPostResponse> getGeneralPostById(@PathVariable Long general_post_id) {
-        GeneralPostResponse post = generalPostService.getGeneralPostById(general_post_id);
-        return ResponseEntity.status(HttpStatus.OK).body(post);
-    }
-    // 게시글 제목으로 조회
-    @GetMapping("?search={title}")
-    public ResponseEntity<GeneralPostResponse> getGeneralPostByTitle(@PathVariable String title) {
-        GeneralPostResponse post = generalPostService.getGeneralPostByTitle(title);
-        return ResponseEntity.status(HttpStatus.OK).body(post);
-    }
-    // 게시글 생성
-    @PostMapping
-    public ResponseEntity<GeneralPostResponse> createGeneralPost(@RequestBody AddGeneralPostRequest request) {
-        GeneralPostResponse post = generalPostService.createGeneralPost(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(post);
-    }
-    // 게시글 수정
-    @PutMapping("/{general_post_id}")
-    public ResponseEntity<GeneralPostResponse> updateGeneralPost(@PathVariable Long general_post_id, @RequestBody UpdateGeneralPostRequest request) {
-        GeneralPostResponse post = generalPostService.updateGeneralPost(general_post_id, request);
-        return ResponseEntity.status(HttpStatus.OK).body(post);
-    }
-    // 게시글 삭제
-    @DeleteMapping("/{general_post_id}")
-    public ResponseEntity<Void> deleteGeneralPost(@PathVariable Long general_post_id) {
-        generalPostService.deleteGeneralPost(general_post_id);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
+	public GeneralPostController(GeneralPostService generalPostService) {
+		this.generalPostService = generalPostService;
+	}
+
+	// 전체 게시글 조회
+	@GetMapping
+	public ResponseEntity<List<GeneralPostResponse>> getAllGeneralPosts() {
+		List<GeneralPostResponse> posts = generalPostService.getAllGeneralPosts();
+		return ResponseEntity.status(HttpStatus.OK).body(posts);
+	}
+
+	// 게시글 id로 조회
+	@GetMapping("/{general_post_id}")
+	public ResponseEntity<GeneralPostResponse> getGeneralPostById(@PathVariable Long general_post_id) {
+		GeneralPostResponse post = generalPostService.getGeneralPostById(general_post_id);
+		return ResponseEntity.status(HttpStatus.OK).body(post);
+	}
+
+	// 게시글 제목으로 조회
+	@GetMapping("?search={title}")
+	public ResponseEntity<GeneralPostResponse> getGeneralPostByTitle(@PathVariable String title) {
+		GeneralPostResponse post = generalPostService.getGeneralPostByTitle(title);
+		return ResponseEntity.status(HttpStatus.OK).body(post);
+	}
+
+	// 게시글 생성
+	@PostMapping
+	public ResponseEntity<GeneralPostResponse> createGeneralPost(@RequestBody AddGeneralPostRequest request,
+		@PathVariable Long generalBoardId) {
+		GeneralPostResponse post = generalPostService.createGeneralPost(request, generalBoardId);
+		return ResponseEntity.status(HttpStatus.CREATED).body(post);
+	}
+
+	// 게시글 수정
+	@PutMapping("/{general_post_id}")
+	public ResponseEntity<GeneralPostResponse> updateGeneralPost(@PathVariable Long general_post_id,
+		@RequestBody UpdateGeneralPostRequest request) {
+		GeneralPostResponse post = generalPostService.updateGeneralPost(general_post_id, request);
+		return ResponseEntity.status(HttpStatus.OK).body(post);
+	}
+
+	// 게시글 삭제
+	@DeleteMapping("/{general_post_id}")
+	public ResponseEntity<Void> deleteGeneralPost(@PathVariable Long general_post_id) {
+		generalPostService.deleteGeneralPost(general_post_id);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/post/controller/QuizPostController.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/controller/QuizPostController.java
@@ -1,64 +1,81 @@
 package com.estsoft.guesshangeul.post.controller;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.estsoft.guesshangeul.post.dto.AddQuizPostRequest;
 import com.estsoft.guesshangeul.post.dto.GetHiddenPostResponse;
 import com.estsoft.guesshangeul.post.dto.QuizPostResponse;
+import com.estsoft.guesshangeul.post.dto.UpdateQuizPostRequest;
 import com.estsoft.guesshangeul.post.service.QuizPostService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/quizBoard/{quiz_board_id}/quizPost")
 public class QuizPostController {
-    private final QuizPostService quizPostService;
+	private final QuizPostService quizPostService;
 
-    public QuizPostController(QuizPostService quizPostService) {
-        this.quizPostService = quizPostService;
-    }
-    // 전체 퀴즈 게시글 조회
-    @GetMapping
-    public ResponseEntity<List<QuizPostResponse>> getAllQuizPosts() {
-        List<QuizPostResponse> posts = quizPostService.getAllQuizPosts();
-        return ResponseEntity.status(HttpStatus.OK).body(posts);
-    }
-    // 퀴즈 게시글 id로 조회
-    @GetMapping("/{quiz_post_id}")
-    public ResponseEntity<QuizPostResponse> getQuizPostById(@PathVariable Long quiz_post_id) {
-        QuizPostResponse post = quizPostService.getQuizPostById(quiz_post_id);
-        return ResponseEntity.status(HttpStatus.OK).body(post);
-    }
-    // 퀴즈 게시글 제목으로 조회
-    @GetMapping("?search={quiz_title}")
-    public ResponseEntity<QuizPostResponse> getQuizPostByTitle(@PathVariable String quiz_title) {
-        QuizPostResponse post = quizPostService.getQuizPostByTitle(quiz_title);
-        return ResponseEntity.status(HttpStatus.OK).body(post);
-    }
-    // 퀴즈 게시글 숨김 여부 조회
-    @GetMapping("?isHidden={isHidden}")
-    public ResponseEntity<List<GetHiddenPostResponse>> getQuizPostByIsHidden(@RequestParam boolean isHidden) {
-        List<GetHiddenPostResponse> posts = quizPostService.getQuizPostByIsHidden(isHidden);
-        return ResponseEntity.status(HttpStatus.OK).body(posts);
-    }
-    // 퀴즈 게시글 생성
-    @PostMapping
-    public ResponseEntity<QuizPostResponse> createQuizPost(@RequestBody AddQuizPostRequest request) {
-        QuizPostResponse post = quizPostService.createQuizPost(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(post);
-    }
-    // 퀴즈 게시글 수정
-    @PutMapping("/{quiz_post_id}")
-    public ResponseEntity<QuizPostResponse> updateQuizPost(@PathVariable Long quiz_post_id, @RequestBody AddQuizPostRequest request) {
-        QuizPostResponse post = quizPostService.updateQuizPost(quiz_post_id, request);
-        return ResponseEntity.status(HttpStatus.OK).body(post);
-    }
-    // 퀴즈 게시글 삭제
-    @DeleteMapping("/{quiz_post_id}")
-    public ResponseEntity<Void> deleteQuizPost(@PathVariable Long quiz_post_id) {
-        quizPostService.deleteQuizPost(quiz_post_id);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
+	public QuizPostController(QuizPostService quizPostService) {
+		this.quizPostService = quizPostService;
+	}
+
+	// 전체 퀴즈 게시글 조회
+	@GetMapping
+	public ResponseEntity<List<QuizPostResponse>> getAllQuizPosts() {
+		List<QuizPostResponse> posts = quizPostService.getAllQuizPosts();
+		return ResponseEntity.status(HttpStatus.OK).body(posts);
+	}
+
+	// 퀴즈 게시글 id로 조회
+	@GetMapping("/{quiz_post_id}")
+	public ResponseEntity<QuizPostResponse> getQuizPostById(@PathVariable Long quiz_post_id) {
+		QuizPostResponse post = quizPostService.getQuizPostById(quiz_post_id);
+		return ResponseEntity.status(HttpStatus.OK).body(post);
+	}
+
+	// 퀴즈 게시글 제목으로 조회
+	@GetMapping("?search={quiz_title}")
+	public ResponseEntity<QuizPostResponse> getQuizPostByTitle(@PathVariable String quiz_title) {
+		QuizPostResponse post = quizPostService.getQuizPostByTitle(quiz_title);
+		return ResponseEntity.status(HttpStatus.OK).body(post);
+	}
+
+	// 퀴즈 게시글 숨김 여부 조회
+	@GetMapping("?isHidden={isHidden}")
+	public ResponseEntity<List<GetHiddenPostResponse>> getQuizPostByIsHidden(@RequestParam boolean isHidden) {
+		List<GetHiddenPostResponse> posts = quizPostService.getQuizPostByIsHidden(isHidden);
+		return ResponseEntity.status(HttpStatus.OK).body(posts);
+	}
+
+	// 퀴즈 게시글 생성
+	@PostMapping
+	public ResponseEntity<QuizPostResponse> createQuizPost(@RequestBody AddQuizPostRequest request) {
+		QuizPostResponse post = quizPostService.createQuizPost(request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(post);
+	}
+
+	// 퀴즈 게시글 수정
+	@PutMapping("/{quiz_post_id}")
+	public ResponseEntity<QuizPostResponse> updateQuizPost(@PathVariable Long quiz_post_id,
+		@RequestBody UpdateQuizPostRequest request) {
+		QuizPostResponse post = quizPostService.updateQuizPost(quiz_post_id, request);
+		return ResponseEntity.status(HttpStatus.OK).body(post);
+	}
+
+	// 퀴즈 게시글 삭제
+	@DeleteMapping("/{quiz_post_id}")
+	public ResponseEntity<Void> deleteQuizPost(@PathVariable Long quiz_post_id) {
+		quizPostService.deleteQuizPost(quiz_post_id);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/post/dto/AddGeneralPostRequest.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/dto/AddGeneralPostRequest.java
@@ -1,8 +1,7 @@
 package com.estsoft.guesshangeul.post.dto;
 
-import com.estsoft.guesshangeul.board.entity.GeneralBoard;
 import com.estsoft.guesshangeul.post.entity.GeneralPost;
-import com.estsoft.guesshangeul.user.entity.Users;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,21 +10,17 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class AddGeneralPostRequest {
-    private Users users;
-    private GeneralBoard generalBoard;
-    private String title;
-    private String content;
-    private boolean isHidden;
-    private Long view;
+	private String title;
+	private String content;
+	private boolean isHidden;
+	private Long view;
 
-    public GeneralPost toEntity() {
-        GeneralPost generalPost = new GeneralPost();
-        generalPost.setUsers(this.users);
-        generalPost.setGeneralBoard(this.generalBoard);
-        generalPost.setTitle(this.title);
-        generalPost.setContent(this.content);
-        generalPost.setHidden(this.isHidden);
-        generalPost.setView(this.view);
-        return generalPost;
-    }
+	public GeneralPost toEntity() {
+		GeneralPost generalPost = new GeneralPost();
+		generalPost.setTitle(this.title);
+		generalPost.setContent(this.content);
+		generalPost.setHidden(this.isHidden);
+		generalPost.setView(this.view);
+		return generalPost;
+	}
 }

--- a/src/main/java/com/estsoft/guesshangeul/post/dto/PostResponse.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/dto/PostResponse.java
@@ -1,0 +1,53 @@
+package com.estsoft.guesshangeul.post.dto;
+
+import java.time.LocalDateTime;
+
+import com.estsoft.guesshangeul.post.entity.GeneralPost;
+import com.estsoft.guesshangeul.post.entity.QuizPost;
+import com.estsoft.guesshangeul.user.dto.UsersResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostResponse {
+	private Long id;
+	private UsersResponse user;
+	private Long boardId;
+	private String title;
+	private String content;
+	private Boolean isHidden;
+	private Long view;
+	private Long commentCount;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	public PostResponse(GeneralPost post) {
+		this.id = post.getId();
+		this.user = new UsersResponse(post.getUsers());
+		this.boardId = post.getGeneralBoard().getId();
+		this.title = post.getTitle();
+		this.content = post.getContent();
+		this.isHidden = post.isHidden();
+		this.view = post.getView();
+		this.createdAt = post.getCreatedAt();
+		this.updatedAt = post.getUpdatedAt();
+	}
+
+	public PostResponse(QuizPost post) {
+		this.id = post.getId();
+		this.user = new UsersResponse(post.getUser());
+		this.boardId = post.getId();
+		this.title = post.getQuizTitle();
+		this.content = post.getHintContent();
+		this.isHidden = post.getIsHidden();
+		this.view = post.getView();
+		this.createdAt = post.getCreatedAt();
+		this.updatedAt = post.getUpdatedAt();
+	}
+}

--- a/src/main/java/com/estsoft/guesshangeul/post/dto/PostResponse.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/dto/PostResponse.java
@@ -45,7 +45,7 @@ public class PostResponse {
 		this.boardId = post.getId();
 		this.title = post.getQuizTitle();
 		this.content = post.getHintContent();
-		this.isHidden = post.getIsHidden();
+		this.isHidden = post.isHidden();
 		this.view = post.getView();
 		this.createdAt = post.getCreatedAt();
 		this.updatedAt = post.getUpdatedAt();

--- a/src/main/java/com/estsoft/guesshangeul/post/repository/GeneralPostRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/repository/GeneralPostRepository.java
@@ -1,12 +1,16 @@
 package com.estsoft.guesshangeul.post.repository;
 
-import com.estsoft.guesshangeul.post.entity.GeneralPost;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.estsoft.guesshangeul.post.entity.GeneralPost;
+
 public interface GeneralPostRepository extends JpaRepository<GeneralPost, Long> {
-    List<GeneralPost> findByGeneralBoardIdAndIdIn(Long generalBoardId, List<Long> id);
-    Optional<GeneralPost> findByTitle(String title);
+	List<GeneralPost> findByGeneralBoardIdAndIdIn(Long generalBoardId, List<Long> id);
+
+	Optional<GeneralPost> findByTitle(String title);
+
+	List<GeneralPost> findTop5ByGeneralBoardIdOrderByCreatedAtDesc(Long generalBoardId);
 }

--- a/src/main/java/com/estsoft/guesshangeul/post/repository/QuizPostRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/repository/QuizPostRepository.java
@@ -10,4 +10,6 @@ import com.estsoft.guesshangeul.post.entity.QuizPost;
 @Repository
 public interface QuizPostRepository extends JpaRepository<QuizPost, Long> {
 	List<QuizPost> findByQuizBoardIdAndIdIn(Long quizBoardId, List<Long> id);
+
+	List<QuizPost> findTop5ByQuizBoardIdOrderByCreatedAtDesc(Long quizBoardId);
 }

--- a/src/main/java/com/estsoft/guesshangeul/post/repository/QuizPostRepository.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/repository/QuizPostRepository.java
@@ -11,7 +11,9 @@ import com.estsoft.guesshangeul.post.entity.QuizPost;
 @Repository
 public interface QuizPostRepository extends JpaRepository<QuizPost, Long> {
 	List<QuizPost> findByQuizBoardIdAndIdIn(Long quizBoardId, List<Long> id);
+
 	Optional<QuizPost> findByQuizTitle(String quizTitle);
+
 	List<QuizPost> findByIsHidden(boolean isHidden);
 
 	List<QuizPost> findTop5ByQuizBoardIdOrderByCreatedAtDesc(Long quizBoardId);

--- a/src/main/java/com/estsoft/guesshangeul/post/service/GeneralPostService.java
+++ b/src/main/java/com/estsoft/guesshangeul/post/service/GeneralPostService.java
@@ -1,62 +1,99 @@
 package com.estsoft.guesshangeul.post.service;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.estsoft.guesshangeul.board.entity.GeneralBoard;
+import com.estsoft.guesshangeul.board.repository.GeneralBoardRepository;
+import com.estsoft.guesshangeul.exception.EntityNotFoundException;
 import com.estsoft.guesshangeul.post.dto.AddGeneralPostRequest;
 import com.estsoft.guesshangeul.post.dto.GeneralPostResponse;
 import com.estsoft.guesshangeul.post.dto.UpdateGeneralPostRequest;
 import com.estsoft.guesshangeul.post.entity.GeneralPost;
 import com.estsoft.guesshangeul.post.repository.GeneralPostRepository;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
+import com.estsoft.guesshangeul.user.entity.Users;
+import com.estsoft.guesshangeul.user.service.UsersDetailsService;
 
 @Service
 public class GeneralPostService {
-    private final GeneralPostRepository generalPostRepository;
+	private final GeneralPostRepository generalPostRepository;
+	private final UsersDetailsService usersDetailsService;
+	private final GeneralBoardRepository generalBoardRepository;
 
-    public GeneralPostService(GeneralPostRepository generalPostRepository) {
-        this.generalPostRepository = generalPostRepository;
-    }
+	public GeneralPostService(GeneralPostRepository generalPostRepository, UsersDetailsService usersDetailsService,
+		GeneralBoardRepository generalBoardRepository) {
+		this.generalPostRepository = generalPostRepository;
+		this.usersDetailsService = usersDetailsService;
+		this.generalBoardRepository = generalBoardRepository;
+	}
 
-    // 모든 게시글 조회
-    public List<GeneralPostResponse> getAllGeneralPosts() {
-        List<GeneralPost> posts = generalPostRepository.findAll();
-        return posts.stream()
-                .map(GeneralPostResponse::new)
-                .collect(Collectors.toList());
-    }
-    // ID로 게시글 조회 (없으면 예외 발생) + 제목 게시글 구현해야함
-    public GeneralPostResponse getGeneralPostById(Long id) {
-        GeneralPost post = generalPostRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("해당 게시글은 존재하지 않습니다."));
-        return new GeneralPostResponse(post);
-    }
-    // 제목으로 게시글 조회
-    public GeneralPostResponse getGeneralPostByTitle(String title) {
-        GeneralPost post = generalPostRepository.findByTitle(title)
-                .orElseThrow(() -> new RuntimeException("해당 제목의 게시글은 존재하지 않습니다."));
-        return new GeneralPostResponse(post);
-    }
+	// 모든 게시글 조회
+	public List<GeneralPostResponse> getAllGeneralPosts() {
+		List<GeneralPost> posts = generalPostRepository.findAll();
+		return posts.stream()
+			.map(GeneralPostResponse::new)
+			.collect(Collectors.toList());
+	}
 
-    // 게시글 생성
-    public GeneralPostResponse createGeneralPost(AddGeneralPostRequest request) {
-        GeneralPost post = request.toEntity();
-        GeneralPost createdPost = generalPostRepository.save(post);
-        return new GeneralPostResponse(createdPost);
-    }
-    // 게시글 수정
-    public GeneralPostResponse updateGeneralPost(Long id, UpdateGeneralPostRequest request) {
-        GeneralPost post = generalPostRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("해당 게시글은 존재하지 않습니다."));
-        post.setTitle(request.getTitle());
-        post.setContent(request.getContent());
-        post.setHidden(request.isHidden());
-        post.setView(request.getView());
-        GeneralPost updatedPost = generalPostRepository.save(post);
-        return new GeneralPostResponse(updatedPost);
-    }
-    // 게시글 삭제
-    public void deleteGeneralPost(Long id) {
-        generalPostRepository.deleteById(id);
-    }
+	// ID로 게시글 조회 (없으면 예외 발생) + 제목 게시글 구현해야함
+	public GeneralPostResponse getGeneralPostById(Long id) {
+		GeneralPost post = generalPostRepository.findById(id)
+			.orElseThrow(() -> new RuntimeException("해당 게시글은 존재하지 않습니다."));
+		return new GeneralPostResponse(post);
+	}
+
+	// 제목으로 게시글 조회
+	public GeneralPostResponse getGeneralPostByTitle(String title) {
+		GeneralPost post = generalPostRepository.findByTitle(title)
+			.orElseThrow(() -> new RuntimeException("해당 제목의 게시글은 존재하지 않습니다."));
+		return new GeneralPostResponse(post);
+	}
+
+	// 게시글 생성
+	@Transactional
+	public GeneralPostResponse createGeneralPost(AddGeneralPostRequest request, Long generalBoardId) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String username;
+		if (authentication.getPrincipal() instanceof UserDetails userDetails) {
+			username = userDetails.getUsername();
+		} else {
+			username = (String)authentication.getPrincipal();
+		}
+		Users users = (Users)usersDetailsService.loadUserByUsername(username);
+
+		Optional<GeneralBoard> generalBoardOptional = generalBoardRepository.findById(generalBoardId);
+		if (generalBoardOptional.isEmpty()) {
+			throw new EntityNotFoundException("GeneralBoard", generalBoardId);
+		}
+
+		GeneralPost post = request.toEntity();
+		post.setUsers(users);
+		post.setGeneralBoard(generalBoardOptional.get());
+		GeneralPost createdPost = generalPostRepository.save(post);
+		return new GeneralPostResponse(createdPost);
+	}
+
+	// 게시글 수정
+	public GeneralPostResponse updateGeneralPost(Long id, UpdateGeneralPostRequest request) {
+		GeneralPost post = generalPostRepository.findById(id)
+			.orElseThrow(() -> new RuntimeException("해당 게시글은 존재하지 않습니다."));
+		post.setTitle(request.getTitle());
+		post.setContent(request.getContent());
+		post.setHidden(request.isHidden());
+		post.setView(request.getView());
+		GeneralPost updatedPost = generalPostRepository.save(post);
+		return new GeneralPostResponse(updatedPost);
+	}
+
+	// 게시글 삭제
+	public void deleteGeneralPost(Long id) {
+		generalPostRepository.deleteById(id);
+	}
 }

--- a/src/main/resources/static/css/postItem.css
+++ b/src/main/resources/static/css/postItem.css
@@ -1,0 +1,7 @@
+.text-1rem {
+    font-size: 1rem;
+}
+
+#edit-btn, #delete-btn {
+    color: blue;
+}

--- a/src/main/resources/templates/common/boardCard.html
+++ b/src/main/resources/templates/common/boardCard.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="kr">
+<th:block th:fragment="boardCard">
+    <div class="list-group">
+        <div class="list-group-item list-group-item-primary text-start"><h4>게시판 제목</h4></div>
+        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
+        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
+        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
+        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
+        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
+    </div>
+</th:block>
+</html>

--- a/src/main/resources/templates/common/boardCard.html
+++ b/src/main/resources/templates/common/boardCard.html
@@ -1,13 +1,25 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="kr">
 <th:block th:fragment="boardCard(board)">
-    <div class="list-group">
-        <a th:switch="${board.boardType}"
-           th:href="${board.boardType == '1' ? '/generalBoard/' + ${board.id} : '/quizBoard/' + ${board.id}}">
-            <h4>게시판 제목</h4></a>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+    <div class="list-group my-3">
+        <li class="list-group-item list-group-item-primary"
+            th:href="${board.boardType == 1 ? '/generalBoard/' + board.id : '/quizBoard/' + board.id}"
+            th:text="${board.title}">
+            <h4>게시판 제목</h4></li>
         <th:block th:each="post : ${board.posts}">
             <th:block
-                    th:replace="~{/common/postItem :: postItem(post, boardId=${board.id}, boardType=${board.boardType})}"></th:block>
+                    th:replace="~{/common/postItem :: postItem(${post}, ${board.id}, ${board.boardType})}"></th:block>
+        </th:block>
+
+        <!-- 빈 공간 채우기 -->
+        <th:block th:if="${#lists.size(board.posts) < 5}">
+            <th:block th:each="i : ${#numbers.sequence(board.posts.size() + 1, 5)}">
+                <div class="list-group-item" style="min-height: 70px;">
+                    <!-- 빈 게시글 자리 -->
+                </div>
+            </th:block>
         </th:block>
     </div>
 </th:block>

--- a/src/main/resources/templates/common/boardCard.html
+++ b/src/main/resources/templates/common/boardCard.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="kr">
-<th:block th:fragment="boardCard">
+<th:block th:fragment="boardCard(board)">
     <div class="list-group">
-        <div class="list-group-item list-group-item-primary text-start"><h4>게시판 제목</h4></div>
-        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
-        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
-        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
-        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
-        <th:block th:replace="~{/common/postItem :: postItem}"></th:block>
+        <a th:switch="${board.boardType}"
+           th:href="${board.boardType == '1' ? '/generalBoard/' + ${board.id} : '/quizBoard/' + ${board.id}}">
+            <h4>게시판 제목</h4></a>
+        <th:block th:each="post : ${board.posts}">
+            <th:block
+                    th:replace="~{/common/postItem :: postItem(post, boardId=${board.id}, boardType=${board.boardType})}"></th:block>
+        </th:block>
     </div>
 </th:block>
 </html>

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -13,8 +13,8 @@
                 </div>
 
                 <ul class="nav flex-grow-1 justify-content-center">
-                    <li><a href="/quizBoard/1" class="nav-link px-3 link-body-emphasis">문제 게시판</a></li>
-                    <li><a href="/communityBoard/1" class="nav-link px-3 link-body-emphasis">커뮤니티</a></li>
+                    <li><a href="/quizBoard" class="nav-link px-3 link-body-emphasis">문제 게시판</a></li>
+                    <li><a href="/generalBoard" class="nav-link px-3 link-body-emphasis">커뮤니티</a></li>
                     <li><a href="/rank" class="nav-link px-3 link-body-emphasis">랭킹</a></li>
                     <li><a sec:authorize="hasRole('KINGSEJONG')" href="/admin" class="nav-link px-3 link-body-emphasis">관리자
                         페이지</a></li>

--- a/src/main/resources/templates/common/postItem.html
+++ b/src/main/resources/templates/common/postItem.html
@@ -1,25 +1,34 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="kr">
-
-<th:block th:fragment="postItem">
-    <link rel="stylesheet" th:href="@{/css/postItem.css}">
-    <div class="list-group-item list-group-item d-flex flex-column py-3">
+<html xmlns:th="http://www.thymeleaf.org">
+<head></head>
+<body>
+<th:block th:fragment="postItem(item, boardId, boardType)">
+    <div class="list-group-item list-group-item-action d-flex flex-column py-3" aria-current="true">
         <div class="row w-100">
             <div class="col d-flex flex-row">
                 <div class="d-flex flex-row flex-grow-1">
-                    <p class="text-1rem px-1 my-0">작성자 / 등급</p>
-                    <small class="opacity-50 text-nowrap px-1">2024.11.08</small>
+                    <p class="text-1rem px-1 my-0" th:text="${item.users.nickname}">작성자</p>
+                    <small class="opacity-50 text-nowrap px-1" th:text="${item.createdAt}">2024.11.08</small>
                 </div>
-                <small class="text-nowrap">조회수 / 댓글수</small>
+                <small class="text-nowrap" th:text="${item.view} + ' / ' + ${item.commentCount}">조회수 / 댓글수</small>
             </div>
         </div>
         <div class="row w-100 d-flex flex-row">
             <div class="col d-flex flex-row">
-                <div class="d-flex flex-grow-1"><p class="text-start fw-bold">게시글 제목</p></div>
-                <div><a id="edit-btn"><small>수정</small></a> <a id="delete-btn"><small>삭제</small></a>
+                <div class="d-flex flex-grow-1">
+                    <a th:if="${boardType == 1}"
+                       th:href="@{/generalBoard/{boardId}/generalPost/{postId}(boardId=${boardId}, postId=${item.id})}"
+                       th:text="${item.title}">게시글 제목</a>
+                    <a th:if="${boardType == 2}"
+                       th:href="@{/quizBoard/{boardId}/quizPost/{postId}(boardId=${boardId}, postId=${item.id})}"
+                       th:text="${item.title}">게시글 제목</a>
+                    <!--                    <p class="text-start fw-bold" th:text="${item.title}">게시글 제목</p></div>-->
+                    <!--                추후 댓글에 활용 가능성-->
+                    <!--                <div th:if=""><a th:href="@{|/board/board_id/${post.id}|}">수정</a> <a th:href="@{|/delete/${post.id}|}">삭제</a>-->
                 </div>
             </div>
         </div>
     </div>
 </th:block>
+</body>
 </html>

--- a/src/main/resources/templates/common/postItem.html
+++ b/src/main/resources/templates/common/postItem.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="kr">
+
+<th:block th:fragment="postItem">
+    <link rel="stylesheet" th:href="@{/css/postItem.css}">
+    <div class="list-group-item list-group-item d-flex flex-column py-3">
+        <div class="row w-100">
+            <div class="col d-flex flex-row">
+                <div class="d-flex flex-row flex-grow-1">
+                    <p class="text-1rem px-1 my-0">작성자 / 등급</p>
+                    <small class="opacity-50 text-nowrap px-1">2024.11.08</small>
+                </div>
+                <small class="text-nowrap">조회수 / 댓글수</small>
+            </div>
+        </div>
+        <div class="row w-100 d-flex flex-row">
+            <div class="col d-flex flex-row">
+                <div class="d-flex flex-grow-1"><p class="text-start fw-bold">게시글 제목</p></div>
+                <div><a id="edit-btn"><small>수정</small></a> <a id="delete-btn"><small>삭제</small></a>
+                </div>
+            </div>
+        </div>
+    </div>
+</th:block>
+</html>

--- a/src/main/resources/templates/common/postItem.html
+++ b/src/main/resources/templates/common/postItem.html
@@ -2,27 +2,24 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head></head>
 <body>
-<th:block th:fragment="postItem(item, boardId, boardType)">
+<th:block th:fragment="postItem(post, boardId, boardType)">
     <div class="list-group-item list-group-item-action d-flex flex-column py-3" aria-current="true">
         <div class="row w-100">
             <div class="col d-flex flex-row">
                 <div class="d-flex flex-row flex-grow-1">
-                    <p class="text-1rem px-1 my-0" th:text="${item.users.nickname}">작성자</p>
-                    <small class="opacity-50 text-nowrap px-1" th:text="${item.createdAt}">2024.11.08</small>
+                    <p class="text-1rem px-1 my-0" th:text="${post.user.nickname}">작성자</p>
+                    <p class="text-1rem px-1 my-0" th:text="${post.user.authority}">등급</p>
+                    <small class="opacity-50 text-nowrap px-1" th:text="${post.createdAt}">2024.11.08</small>
                 </div>
-                <small class="text-nowrap" th:text="${item.view} + ' / ' + ${item.commentCount}">조회수 / 댓글수</small>
+                <small class="text-nowrap" th:text="${post.view} + ' / ' + ${post.commentCount}">조회수 / 댓글수</small>
             </div>
         </div>
         <div class="row w-100 d-flex flex-row">
             <div class="col d-flex flex-row">
                 <div class="d-flex flex-grow-1">
                     <a th:if="${boardType == 1}"
-                       th:href="@{/generalBoard/{boardId}/generalPost/{postId}(boardId=${boardId}, postId=${item.id})}"
-                       th:text="${item.title}">게시글 제목</a>
-                    <a th:if="${boardType == 2}"
-                       th:href="@{/quizBoard/{boardId}/quizPost/{postId}(boardId=${boardId}, postId=${item.id})}"
-                       th:text="${item.title}">게시글 제목</a>
-                    <!--                    <p class="text-start fw-bold" th:text="${item.title}">게시글 제목</p></div>-->
+                       th:href="${board.boardType == 1 ? '/generalBoard/' + boardId + '/generalPost/' + post.id : '/quizBoard/' + boardId + '/quizPost/' + post.id}"
+                       th:text="${post.title}">게시글 제목</a>
                     <!--                추후 댓글에 활용 가능성-->
                     <!--                <div th:if=""><a th:href="@{|/board/board_id/${post.id}|}">수정</a> <a th:href="@{|/delete/${post.id}|}">삭제</a>-->
                 </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,16 +1,30 @@
-<!DOCTYPE html>
-<html lang="ko">
+<!doctype html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{/common/sideContentLayout}">
 <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>홈페이지</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css">
+    <title>홈 페이지</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 
 <body>
-<h2>INDEX</h2>
-<button type="button" class="btn btn-secondary" onclick="location.href='/api/logout'">로그아웃</button>
+<div layout:fragment="content">
+    <div class="container">
+        <!--        <div th:each="i : ${#numbers.sequence(0, boards.size() - 1, 2)}" class="row">-->
+        <div th:each="i : ${#numbers.sequence(0, 3, 2)}" class="row py-3">
+            <div class="col">
+                <th:block th:replace="~{/common/boardCard :: boardCard}"></th:block>
+            </div>
+            <div class="col">
+                <th:block th:replace="~{/common/boardCard :: boardCard}"></th:block>
+            </div>
+            <!--            <div class="col" th:text="${boards[i]}">Item</div>-->
+            <!--            <div class="col" th:text="${i + 1 < boards.size() ? items[i + 1] : ''}">Item</div>-->
+        </div>
+    </div>
+</div>
 </body>
 
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -13,13 +13,6 @@
 <div layout:fragment="content">
     <div class="container">
         <div th:each="i : ${#numbers.sequence(0, boards.size() - 1, 2)}" class="row">
-            <!--        <div th:each="i : ${#numbers.sequence(0, 3, 2)}" class="row py-3">-->
-            <!--            <div class="col">-->
-            <!--                <th:block th:replace="~{/common/boardCard :: boardCard}"></th:block>-->
-            <!--            </div>-->
-            <!--            <div class="col">-->
-            <!--                <th:block th:replace="~{/common/boardCard :: boardCard}"></th:block>-->
-            <!--            </div>-->
             <div class="col">
                 <th:block th:replace="~{/common/boardCard :: boardCard(board=${boards[i]})}"></th:block>
             </div>
@@ -27,7 +20,7 @@
                 <th:block th:if="${i + 1 < boards.size()}"
                           th:replace="~{/common/boardCard :: boardCard(board=${boards[i+1]})}"></th:block>
             </div>
-            
+
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -12,16 +12,22 @@
 <body>
 <div layout:fragment="content">
     <div class="container">
-        <!--        <div th:each="i : ${#numbers.sequence(0, boards.size() - 1, 2)}" class="row">-->
-        <div th:each="i : ${#numbers.sequence(0, 3, 2)}" class="row py-3">
+        <div th:each="i : ${#numbers.sequence(0, boards.size() - 1, 2)}" class="row">
+            <!--        <div th:each="i : ${#numbers.sequence(0, 3, 2)}" class="row py-3">-->
+            <!--            <div class="col">-->
+            <!--                <th:block th:replace="~{/common/boardCard :: boardCard}"></th:block>-->
+            <!--            </div>-->
+            <!--            <div class="col">-->
+            <!--                <th:block th:replace="~{/common/boardCard :: boardCard}"></th:block>-->
+            <!--            </div>-->
             <div class="col">
-                <th:block th:replace="~{/common/boardCard :: boardCard}"></th:block>
+                <th:block th:replace="~{/common/boardCard :: boardCard(board=${boards[i]})}"></th:block>
             </div>
             <div class="col">
-                <th:block th:replace="~{/common/boardCard :: boardCard}"></th:block>
+                <th:block th:if="${i + 1 < boards.size()}"
+                          th:replace="~{/common/boardCard :: boardCard(board=${boards[i+1]})}"></th:block>
             </div>
-            <!--            <div class="col" th:text="${boards[i]}">Item</div>-->
-            <!--            <div class="col" th:text="${i + 1 < boards.size() ? items[i + 1] : ''}">Item</div>-->
+            
         </div>
     </div>
 </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

#67 #40 

## 📝작업 내용

### 템플릿 페이지 구현
- 게시판 Card 구현
- 게시글 리스트 구현
- 전체 게시글 조회 결과 적용
### 전체 게시판 조회 API 수정
- 수정 전: 일반/문제 게시판 정보만 조회
- 수정 후: 일반/문제 게시판 6개를 각 게시판마다 5개 게시글 매핑한 데이터 조회
- 홈페이지에서 게시판 및 게시글 데이터 활용
### 이슈
- 현재 유저의 등급이 users 테이블에 저장되지 않는 상태 (게시글의 작성자 등급 확인 불가)
- N+1 문제 발생 가능성 -> fetch join 등 해결책 필요
- 조회수, 댓글수 테스트 미확인

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/c74059d6-ee1e-4507-ab37-e5e0e8454309)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요